### PR TITLE
Fix CI test file paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "pnpm --filter playground dev",
     "build": "pnpm --filter playground build",
-    "test": "node --import tsx --test \"packages/**/*.test.ts\"",
+    "test": "node --import tsx --test packages/core/test/collision.test.ts packages/core/test/input-runtime.test.ts packages/core/test/math.test.ts packages/gameplay/test/presets.test.ts packages/gameplay/test/scene.test.ts",
     "typecheck": "pnpm -r --workspace-concurrency=1 --if-present typecheck && pnpm exec tsc -p tsconfig.test.json --noEmit",
     "verify": "pnpm typecheck && pnpm test && pnpm build"
   },


### PR DESCRIPTION
## Summary
- Replace the quoted recursive test glob with explicit TypeScript test file paths
- Keeps pnpm test cross-platform while avoiding Ubuntu treating the glob as a literal path

## Verification
- pnpm.cmd verify