### PR TITLE
Add package-based release versioning

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,83 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump to apply when an exact version is not provided.
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      version:
+        description: Optional exact version, for example 0.2.0.
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Bump package versions
+        run: pnpm version:bump -- --bump "${{ inputs.bump }}" --version "${{ inputs.version }}"
+
+      - name: Update lockfile
+        run: pnpm install --lockfile-only
+
+      - name: Verify workspace
+        run: pnpm verify
+
+      - name: Open release pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          BRANCH="release/v${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "${BRANCH}"
+          git add package.json packages/*/package.json pnpm-lock.yaml
+          git commit -m "Release v${VERSION}"
+          git push --set-upstream origin "${BRANCH}"
+
+          cat > release-pr-body.md <<EOF
+          ## Summary
+          - bump package versions to v${VERSION}
+          - update the pnpm lockfile
+
+          ## Verification
+          - pnpm verify
+          EOF
+
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "Release v${VERSION}" \
+            --body-file release-pr-body.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - package.json
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          TAG="v${VERSION}"
+
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "${TAG}"
+          git push origin "${TAG}"
+          gh release create "${TAG}" --title "${TAG}" --generate-notes

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,31 @@
+# Release Process
+
+Mochi uses `package.json` versions as the release source of truth.
+
+## Prepare a Release
+
+1. Open the **Prepare Release** workflow in GitHub Actions.
+2. Choose a `patch`, `minor`, or `major` bump, or provide an exact version.
+3. Run the workflow.
+
+The workflow updates the root package and every versioned package under `packages/*`, refreshes `pnpm-lock.yaml`, runs `pnpm verify`, and opens a release pull request.
+
+## Publish a Release
+
+Merge the release pull request into `main`.
+
+After the merge, the **Release** workflow reads the root `package.json` version, creates the matching `vX.Y.Z` tag if it does not already exist, and generates a GitHub release.
+
+## Local Checks
+
+Use this command to confirm package versions are synced:
+
+```bash
+pnpm version:check
+```
+
+Use this command to test a local bump before reverting it:
+
+```bash
+pnpm version:bump -- --bump patch
+```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mochi",
+  "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "workspaces": [
@@ -10,8 +11,10 @@
     "dev": "pnpm --filter playground dev",
     "build": "pnpm --filter playground build",
     "test": "node --import tsx --test packages/core/test/collision.test.ts packages/core/test/input-runtime.test.ts packages/core/test/math.test.ts packages/gameplay/test/presets.test.ts packages/gameplay/test/scene.test.ts",
+    "version:bump": "node scripts/bump-version.mjs",
+    "version:check": "node scripts/bump-version.mjs --check",
     "typecheck": "pnpm -r --workspace-concurrency=1 --if-present typecheck && pnpm exec tsc -p tsconfig.test.json --noEmit",
-    "verify": "pnpm typecheck && pnpm test && pnpm build"
+    "verify": "pnpm version:check && pnpm typecheck && pnpm test && pnpm build"
   },
   "devDependencies": {
     "@types/node": "22.0.0",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,146 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import process from 'node:process';
+
+const args = parseArgs(process.argv.slice(2));
+const root = process.cwd();
+const packageFiles = await findVersionedPackageFiles();
+const rootPackagePath = join(root, 'package.json');
+const rootPackage = await readJson(rootPackagePath);
+const currentVersion = rootPackage.version;
+
+if (!currentVersion) {
+  fail('Root package.json must define a version.');
+}
+
+if (args.check) {
+  const mismatches = [];
+  for (const file of packageFiles) {
+    const manifest = await readJson(file);
+    if (manifest.version !== currentVersion) {
+      mismatches.push(`${relative(file)} has ${manifest.version}, expected ${currentVersion}`);
+    }
+  }
+
+  if (mismatches.length > 0) {
+    fail(`Package versions are out of sync:\n${mismatches.join('\n')}`);
+  }
+
+  console.log(`All package versions are synced at ${currentVersion}.`);
+  process.exit(0);
+}
+
+const nextVersion = args.version || bumpVersion(currentVersion, args.bump || 'patch');
+validateVersion(nextVersion);
+
+if (nextVersion === currentVersion) {
+  fail(`Next version must be different from the current version (${currentVersion}).`);
+}
+
+for (const file of [rootPackagePath, ...packageFiles]) {
+  const manifest = await readJson(file);
+  if (!manifest.version) {
+    continue;
+  }
+
+  manifest.version = nextVersion;
+  await writeJson(file, manifest);
+}
+
+console.log(`Updated package versions: ${currentVersion} -> ${nextVersion}`);
+
+function parseArgs(argv) {
+  const parsed = {};
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+
+    if (arg === '--check') {
+      parsed.check = true;
+      continue;
+    }
+
+    if (arg === '--version') {
+      parsed.version = argv[++index]?.trim();
+      continue;
+    }
+
+    if (arg === '--bump') {
+      parsed.bump = argv[++index]?.trim();
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  if (parsed.version === '') {
+    delete parsed.version;
+  }
+
+  return parsed;
+}
+
+async function findVersionedPackageFiles() {
+  const packagesDir = join(root, 'packages');
+  const packageNames = await readdir(packagesDir);
+  const files = [];
+
+  for (const packageName of packageNames) {
+    const packagePath = join(packagesDir, packageName, 'package.json');
+    const manifest = await readJson(packagePath);
+
+    if (manifest.version) {
+      files.push(packagePath);
+    }
+  }
+
+  return files.sort();
+}
+
+function bumpVersion(version, bump) {
+  validateVersion(version);
+
+  const [core] = version.split('-');
+  const parts = core.split('.').map((part) => Number.parseInt(part, 10));
+
+  if (parts.length !== 3 || parts.some((part) => Number.isNaN(part))) {
+    fail(`Unsupported version format: ${version}`);
+  }
+
+  if (bump === 'major') {
+    return `${parts[0] + 1}.0.0`;
+  }
+
+  if (bump === 'minor') {
+    return `${parts[0]}.${parts[1] + 1}.0`;
+  }
+
+  if (bump === 'patch') {
+    return `${parts[0]}.${parts[1]}.${parts[2] + 1}`;
+  }
+
+  fail(`Unsupported bump type: ${bump}. Use major, minor, or patch.`);
+}
+
+function validateVersion(version) {
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    fail(`Invalid version: ${version}`);
+  }
+}
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file, 'utf8'));
+}
+
+async function writeJson(file, value) {
+  await writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function relative(file) {
+  return file.replace(`${root}\\`, '').replace(`${root}/`, '');
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add root package version as the release source of truth
- add package version sync and bump scripts
- add GitHub Actions to prepare release PRs and publish GitHub releases after merge
- document the release process

## Verification
- pnpm version:check
- pnpm verify

Note: local .gitignore edits were intentionally left out of this PR.