### PR TITLE
Add arcade spaceflight controller and demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 *.local
 .DS_Store
+.vite-dev.*
+.env

--- a/apps/playground/src/App.vue
+++ b/apps/playground/src/App.vue
@@ -6,15 +6,24 @@ import FirstPersonRangeDemo from './demos/FirstPersonRangeDemo.vue';
 import NightfallDemo from './DemoScene.vue';
 import OrbitalIslandsDemo from './demos/OrbitalIslandsDemo.vue';
 import PresetLabDemo from './demos/PresetLabDemo.vue';
+import StarfieldDriftDemo from './demos/StarfieldDriftDemo.vue';
 import TacticsBoardDemo from './demos/TacticsBoardDemo.vue';
 import VelocityCircuitDemo from './demos/VelocityCircuitDemo.vue';
 
-type DemoId = 'nightfall' | 'orbital' | 'velocity' | 'presets' | 'range' | 'tactics';
+type DemoId =
+  | 'nightfall'
+  | 'orbital'
+  | 'starfield'
+  | 'velocity'
+  | 'presets'
+  | 'range'
+  | 'tactics';
 
 const selectedDemo = shallowRef<DemoId>('nightfall');
 const demos = [
   { id: 'nightfall', label: 'Nightfall Run', component: NightfallDemo },
   { id: 'orbital', label: 'Orbital Islands', component: OrbitalIslandsDemo },
+  { id: 'starfield', label: 'Starfield Drift', component: StarfieldDriftDemo },
   { id: 'velocity', label: 'Velocity Circuit', component: VelocityCircuitDemo },
   { id: 'presets', label: 'Preset Lab', component: PresetLabDemo },
   { id: 'range', label: 'First Person Range', component: FirstPersonRangeDemo },

--- a/apps/playground/src/demos/PresetLabDemo.vue
+++ b/apps/playground/src/demos/PresetLabDemo.vue
@@ -5,7 +5,7 @@ import {
   createControllerPreset,
   type ControllerPresetKind,
   type Entity,
-  type ThirdPersonController,
+  type PresetController,
 } from '@mochi/gameplay';
 import { computed, onBeforeUnmount, shallowRef } from 'vue';
 import DemoHud from '../components/DemoHud.vue';
@@ -19,6 +19,7 @@ const presetLabels: Record<ControllerPresetKind, string> = {
   sideScroller2D: 'Side Scroller',
   vehicleArcade: 'Vehicle Arcade',
   vehicleSim: 'Vehicle Sim',
+  spaceflightArcade: 'Spaceflight Arcade',
   railCamera: 'Rail Camera',
   strategyFreeCam: 'Strategy Free Cam',
 };
@@ -26,7 +27,7 @@ const presetLabels: Record<ControllerPresetKind, string> = {
 const game = useGame();
 const scene = game.createScene();
 const selectedPreset = shallowRef<ControllerPresetKind>('thirdPersonOrbit');
-let controller: ThirdPersonController | null = null;
+let controller: PresetController | null = null;
 scene.addCleanup(() => {
   controller?.dispose();
 });
@@ -71,10 +72,14 @@ function selectPreset(kind: ControllerPresetKind): void {
   controller?.dispose();
   selectedPreset.value = kind;
   scene.reset();
+  const bounds =
+    kind === 'spaceflightArcade'
+      ? { minX: -11.5, maxX: 11.5, minY: 0.7, maxY: 8, minZ: -11.5, maxZ: 11.5 }
+      : { minX: -11.5, maxX: 11.5, minZ: -11.5, maxZ: 11.5 };
   controller = createControllerPreset(game, kind, {
     target: player,
     groundY: 0.7,
-    bounds: { minX: -11.5, maxX: 11.5, minZ: -11.5, maxZ: 11.5 },
+    bounds,
   });
 }
 

--- a/apps/playground/src/demos/StarfieldDriftDemo.vue
+++ b/apps/playground/src/demos/StarfieldDriftDemo.vue
@@ -1,0 +1,235 @@
+<script setup lang="ts">
+import { useGame } from '@mochi/vue';
+import {
+  createSpaceflightArcadeController,
+  getSpaceflightForward,
+  type Entity,
+} from '@mochi/gameplay';
+import { computed, onBeforeUnmount, shallowRef } from 'vue';
+import DemoHud from '../components/DemoHud.vue';
+
+interface Beacon {
+  entity: Entity;
+  collected: boolean;
+  baseScale: number;
+  phase: number;
+}
+
+const game = useGame();
+const scene = game.createScene();
+const beaconsCollected = shallowRef(0);
+const missionState = shallowRef<'running' | 'complete'>('running');
+const speed = shallowRef(0);
+const altitude = shallowRef(0);
+
+const ship = scene.createEntity({
+  id: 'drift-runner',
+  transform: {
+    position: { x: 0, y: 3, z: 10 },
+    scale: { x: 0.9, y: 0.35, z: 1.8 },
+  },
+  renderable: {
+    primitive: 'cube',
+    material: { color: { x: 0.28, y: 0.95, z: 0.78 } },
+  },
+});
+
+const nose = createBox('ship-nose', 0, 3, 8.65, 0.38, 0.28, 0.6, {
+  x: 0.85,
+  y: 1,
+  z: 0.74,
+});
+const leftWing = createBox('left-wing', -0.9, 3, 10.25, 0.9, 0.16, 0.9, {
+  x: 0.16,
+  y: 0.58,
+  z: 1,
+});
+const rightWing = createBox('right-wing', 0.9, 3, 10.25, 0.9, 0.16, 0.9, {
+  x: 0.16,
+  y: 0.58,
+  z: 1,
+});
+const engineGlow = createBox('engine-glow', 0, 3, 11.15, 0.55, 0.18, 0.24, {
+  x: 0.35,
+  y: 0.75,
+  z: 1,
+});
+
+const beacons: Beacon[] = [
+  createBeacon('beacon-1', -7, 2.4, -8, 0.9, 0),
+  createBeacon('beacon-2', 6, 6.2, -18, 0.95, 1.2),
+  createBeacon('beacon-3', -3, 9.5, -29, 1, 2.4),
+  createBeacon('beacon-4', 8.5, 4.8, -41, 1.05, 3.5),
+  createBeacon('beacon-5', 0, 7.4, -54, 1.1, 4.4),
+];
+
+for (let i = 0; i < 72; i += 1) {
+  const lane = (i % 9) - 4;
+  const band = Math.floor(i / 9);
+  createBox(
+    `star-${i}`,
+    lane * 4.8 + Math.sin(i * 2.1) * 1.5,
+    1 + ((i * 7) % 13),
+    -band * 8 - 6 - Math.cos(i) * 2,
+    0.08,
+    0.08,
+    0.08,
+    { x: 0.75, y: 0.88, z: 1 },
+  );
+}
+
+for (let i = 0; i < 10; i += 1) {
+  createBox(
+    `asteroid-${i}`,
+    Math.sin(i * 1.7) * 12,
+    1.4 + ((i * 3) % 7),
+    -10 - i * 5.8,
+    0.9 + (i % 3) * 0.35,
+    0.7 + (i % 2) * 0.25,
+    0.9 + (i % 4) * 0.28,
+    { x: 0.22, y: 0.21, z: 0.28 },
+  );
+}
+
+const controller = createSpaceflightArcadeController(game, {
+  target: ship,
+  enabled: () => missionState.value === 'running',
+  bounds: { minX: -16, maxX: 16, minY: 0.8, maxY: 14, minZ: -62, maxZ: 14 },
+});
+scene.add(controller);
+scene.addReset(() => {
+  beaconsCollected.value = 0;
+  missionState.value = 'running';
+  controller.reset();
+
+  for (const beacon of beacons) {
+    beacon.collected = false;
+  }
+});
+
+const label = computed(() => {
+  const status =
+    missionState.value === 'complete'
+      ? 'route complete'
+      : `${beaconsCollected.value}/${beacons.length} beacons`;
+  return `${status}  |  ${speed.value.toFixed(1)} m/s  |  altitude ${altitude.value.toFixed(1)}`;
+});
+
+scene.onFrame(({ delta, elapsed }) => {
+  speed.value = controller.getSpeed();
+  altitude.value = ship.transform.position.y;
+  syncShipParts();
+
+  const flame = 0.7 + Math.sin(elapsed * 18) * 0.25 + Math.min(speed.value / 24, 1) * 0.55;
+  engineGlow.transform.scale.z = 0.24 * flame;
+
+  for (const beacon of beacons) {
+    beacon.entity.transform.rotation.y += delta * 1.8;
+    beacon.entity.transform.rotation.x += delta * 0.9;
+    beacon.entity.transform.position.y += Math.sin(elapsed * 2.4 + beacon.phase) * 0.002;
+
+    const visibleScale = beacon.collected ? 0 : beacon.baseScale;
+    beacon.entity.transform.scale.x = visibleScale;
+    beacon.entity.transform.scale.y = visibleScale;
+    beacon.entity.transform.scale.z = visibleScale;
+
+    if (!beacon.collected && distance3d(ship, beacon.entity) < 1.7) {
+      beacon.collected = true;
+      beaconsCollected.value += 1;
+      if (beaconsCollected.value === beacons.length) {
+        missionState.value = 'complete';
+      }
+    }
+  }
+});
+
+onBeforeUnmount(() => {
+  scene.dispose();
+});
+
+function syncShipParts(): void {
+  const forward = getSpaceflightForward(ship);
+  const yaw = ship.transform.rotation.y;
+  const right = { x: Math.cos(yaw), z: Math.sin(yaw) };
+
+  setPartTransform(nose, forward, right, 1.05, 0);
+  setPartTransform(leftWing, forward, right, -0.15, -0.95);
+  setPartTransform(rightWing, forward, right, -0.15, 0.95);
+  setPartTransform(engineGlow, forward, right, -1.05, 0);
+}
+
+function setPartTransform(
+  part: Entity,
+  forward: { x: number; y: number; z: number },
+  right: { x: number; z: number },
+  forwardOffset: number,
+  rightOffset: number,
+): void {
+  part.transform.position.x =
+    ship.transform.position.x + forward.x * forwardOffset + right.x * rightOffset;
+  part.transform.position.y = ship.transform.position.y + forward.y * forwardOffset;
+  part.transform.position.z =
+    ship.transform.position.z + forward.z * forwardOffset + right.z * rightOffset;
+  part.transform.rotation.x = ship.transform.rotation.x;
+  part.transform.rotation.y = ship.transform.rotation.y;
+  part.transform.rotation.z = ship.transform.rotation.z;
+}
+
+function createBeacon(
+  id: string,
+  x: number,
+  y: number,
+  z: number,
+  baseScale: number,
+  phase: number,
+): Beacon {
+  return {
+    entity: createBox(id, x, y, z, baseScale, baseScale, baseScale, {
+      x: 0.25,
+      y: 0.92,
+      z: 1,
+    }),
+    collected: false,
+    baseScale,
+    phase,
+  };
+}
+
+function createBox(
+  id: string,
+  x: number,
+  y: number,
+  z: number,
+  sx: number,
+  sy: number,
+  sz: number,
+  color: { x: number; y: number; z: number },
+): Entity {
+  return scene.createEntity({
+    id,
+    transform: {
+      position: { x, y, z },
+      scale: { x: sx, y: sy, z: sz },
+    },
+    renderable: {
+      primitive: 'cube',
+      material: { color },
+    },
+  });
+}
+
+function distance3d(a: Entity, b: Entity): number {
+  const dx = a.transform.position.x - b.transform.position.x;
+  const dy = a.transform.position.y - b.transform.position.y;
+  const dz = a.transform.position.z - b.transform.position.z;
+  return Math.hypot(dx, dy, dz);
+}
+</script>
+
+<template>
+  <DemoHud
+    mode="STARFIELD DRIFT"
+    :title="label"
+    hint="W thrust. S brake. A/D yaw. R/F pitch. Q/E roll. Space/Shift strafe vertically."
+  />
+</template>

--- a/docs/PRESET_GUIDE.md
+++ b/docs/PRESET_GUIDE.md
@@ -12,6 +12,7 @@ Pick presets by camera/control model first, then genre.
 - `sideScroller2D` - side view movement lane
 - `vehicleArcade` - fast, forgiving throttle/brake/steer vehicle movement
 - `vehicleSim` - heavier vehicle movement with slower acceleration and steadier steering
+- `spaceflightArcade` - open 3D spacecraft movement with thrust, pitch, yaw, roll, vertical strafe, and chase camera
 - `railCamera` - constrained cinematic movement
 - `strategyFreeCam` - detached map camera
 
@@ -23,8 +24,9 @@ Pick presets by camera/control model first, then genre.
 - ARPG/RTS-lite -> `isometric` or `topDown`
 - Kart/arcade racer -> `vehicleArcade`
 - Sim racer -> `vehicleSim`
+- Small space game -> `spaceflightArcade`
 
-Use the playground `Preset Lab` demo to switch these camera/control models live. Use `First Person Range` for a focused `firstPerson` example, and `Tactics Board` for an `isometric` example.
+Use the playground `Preset Lab` demo to switch these camera/control models live. Use `First Person Range` for a focused `firstPerson` example, `Tactics Board` for an `isometric` example, and `Starfield Drift` for a `spaceflightArcade` example.
 
 ## API patterns
 
@@ -153,12 +155,34 @@ const controller = createThirdPersonOrbitController(game, {
 });
 ```
 
+### Spaceflight controls
+
+```ts
+import { createSpaceflightArcadeController } from '@mochi/gameplay';
+
+const controller = createSpaceflightArcadeController(game, {
+  target: ship,
+  bounds: { minX: -50, maxX: 50, minY: -10, maxY: 30, minZ: -200, maxZ: 50 },
+  input: {
+    thrust: 'KeyW',
+    brake: 'KeyS',
+    yawLeft: 'KeyA',
+    yawRight: 'KeyD',
+    pitchUp: 'KeyR',
+    pitchDown: 'KeyF',
+    rollLeft: 'KeyQ',
+    rollRight: 'KeyE',
+  },
+});
+```
+
 ## Tuning tips
 
 - Start with movement speed and camera distance.
 - Presets accept configurable keyboard bindings through `input`.
 - In vehicle presets, `forward` and `backward` map to throttle and brake.
 - For vehicle presets, tune `acceleration`, `maxSpeed`, `drag`, and `turnSpeed`.
+- In spaceflight presets, tune `thrust`, `maxSpeed`, `drag`, pitch/yaw/roll speeds, and 3D bounds.
 - Tune sensitivity and camera lerp before adding special logic.
 - Keep defaults unless you have a clear gameplay reason.
 - Add a new preset only if multiple projects need the same tuned profile.

--- a/docs/RECENT_CHANGES.md
+++ b/docs/RECENT_CHANGES.md
@@ -15,6 +15,7 @@ This recap covers the latest engine and playground work after the initial core/r
 - Added configurable keyboard bindings for character and vehicle controllers while keeping WASD/arrows as the default path.
 - Added simple material presets and `createMaterial()` for current solid-color rendering.
 - Reworked `vehicleArcade` and `vehicleSim` to use vehicle-style throttle, braking, steering, drag, and chase camera behavior instead of character-style movement.
+- Added `spaceflightArcade`, a spacecraft controller preset for open 3D movement with thrust, pitch, yaw, roll, vertical strafe, velocity readout, and chase camera behavior.
 
 ## Rendering
 
@@ -32,6 +33,7 @@ This recap covers the latest engine and playground work after the initial core/r
 - Added `Preset Lab`, a live sandbox for switching between all controller presets.
 - Added `First Person Range`, a dedicated `firstPerson` demo with signal collection, a timer, and reset support.
 - Added `Tactics Board`, an `isometric` demo with blockers, capture zones, and reset support.
+- Added `Starfield Drift`, a small spaceflight demo with beacons, asteroids, starfield markers, and ship HUD telemetry.
 - Added a `Tactics Board` debug toggle for showing blocker collision bounds and the controlled unit target.
 - Updated `Velocity Circuit` to show speed and use the new vehicle controller feel.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,8 +26,9 @@ The engine should not become complex by default. AAA-level capability should be 
 - Playground has multiple demos:
   - `Nightfall Run`
   - `Orbital Islands`
-  - `Velocity Circuit`
-  - `Preset Lab`
+- `Velocity Circuit`
+- `Starfield Drift`
+- `Preset Lab`
   - `First Person Range`
   - `Tactics Board`
 
@@ -72,6 +73,7 @@ The engine should not become complex by default. AAA-level capability should be 
 - [x] Add a first-person demo.
 - [x] Add a top-down or isometric tactics demo.
 - [x] Improve `Velocity Circuit` with vehicle-feeling steering instead of character-style movement.
+- [x] Add a first spaceflight demo and reusable arcade spacecraft controller.
 - [x] Add visual debug toggles.
 
 ## Medium-term checklist
@@ -101,6 +103,7 @@ The engine should not become complex by default. AAA-level capability should be 
 - [ ] Add instancing and batching for scale.
 - [ ] Add WebGPU backend exploration after WebGL2 renderer matures.
 - [ ] Advanced LOD presets and support
+- [ ] ray tracing support
 
 ### Assets and animation
 
@@ -123,6 +126,8 @@ The engine should not become complex by default. AAA-level capability should be 
 - [ ] Add starter templates by game style.
 - [ ] Add example cookbook.
 - [ ] Add profiling and performance guidance.
+- [ ] Multiplayer support
+- [ ] Anti Cheat
 
 ### Ecosystem
 
@@ -130,6 +135,8 @@ The engine should not become complex by default. AAA-level capability should be 
 - [ ] Add package/versioning strategy.
 - [ ] Create project website/docs site.
 - [ ] Add community demo gallery when ready.
+- [ ] Tauri support for desktop native and mobile native games
+- [ ] Support for React and Svelte
 
 ## Design principles
 

--- a/packages/gameplay/src/bindings.ts
+++ b/packages/gameplay/src/bindings.ts
@@ -18,6 +18,19 @@ export interface VehicleInputBindings {
   right: KeyBinding;
 }
 
+export interface SpaceflightInputBindings {
+  thrust: KeyBinding;
+  brake: KeyBinding;
+  yawLeft: KeyBinding;
+  yawRight: KeyBinding;
+  pitchUp: KeyBinding;
+  pitchDown: KeyBinding;
+  rollLeft: KeyBinding;
+  rollRight: KeyBinding;
+  strafeUp: KeyBinding;
+  strafeDown: KeyBinding;
+}
+
 export const DEFAULT_CHARACTER_INPUT_BINDINGS: CharacterInputBindings = {
   forward: ['KeyW', 'ArrowUp'],
   backward: ['KeyS', 'ArrowDown'],
@@ -32,6 +45,19 @@ export const DEFAULT_VEHICLE_INPUT_BINDINGS: VehicleInputBindings = {
   backward: ['KeyS', 'ArrowDown'],
   left: ['KeyA', 'ArrowLeft'],
   right: ['KeyD', 'ArrowRight'],
+};
+
+export const DEFAULT_SPACEFLIGHT_INPUT_BINDINGS: SpaceflightInputBindings = {
+  thrust: ['KeyW', 'ArrowUp'],
+  brake: ['KeyS', 'ArrowDown'],
+  yawLeft: ['KeyA', 'ArrowLeft'],
+  yawRight: ['KeyD', 'ArrowRight'],
+  pitchUp: ['KeyR'],
+  pitchDown: ['KeyF'],
+  rollLeft: ['KeyQ'],
+  rollRight: ['KeyE'],
+  strafeUp: 'Space',
+  strafeDown: ['ShiftLeft', 'ShiftRight'],
 };
 
 export function isBindingDown(input: InputState, binding: KeyBinding): boolean {

--- a/packages/gameplay/src/index.ts
+++ b/packages/gameplay/src/index.ts
@@ -1,11 +1,13 @@
 export { createGame, type Game, type GameOptions, type GameStats } from './game';
 export {
   DEFAULT_CHARACTER_INPUT_BINDINGS,
+  DEFAULT_SPACEFLIGHT_INPUT_BINDINGS,
   DEFAULT_VEHICLE_INPUT_BINDINGS,
   isBindingDown,
   wasBindingPressed,
   type CharacterInputBindings,
   type KeyBinding,
+  type SpaceflightInputBindings,
   type VehicleInputBindings,
 } from './bindings';
 export {
@@ -38,6 +40,7 @@ export {
   createIsometricController,
   createRailCameraController,
   createSideScroller2DController,
+  createSpaceflightArcadeController,
   createStrategyFreeCamController,
   createThirdPersonOrbitController,
   createThirdPersonOverShoulderController,
@@ -45,7 +48,9 @@ export {
   createVehicleArcadeController,
   createVehicleSimController,
   type ControllerPresetKind,
+  type PresetController,
   type PresetControllerOptions,
+  type SpaceflightPresetControllerOptions,
   type VehiclePresetControllerOptions,
 } from './presets';
 export {
@@ -71,6 +76,12 @@ export {
   type MountedScene,
   type SceneSetup,
 } from './scene';
+export {
+  createSpaceflightController,
+  getSpaceflightForward,
+  type SpaceflightController,
+  type SpaceflightControllerOptions,
+} from './spaceflight';
 export {
   createVehicleController,
   type VehicleController,

--- a/packages/gameplay/src/presets.ts
+++ b/packages/gameplay/src/presets.ts
@@ -11,6 +11,11 @@ import {
   type VehicleController,
   type VehicleControllerOptions,
 } from './vehicle';
+import {
+  createSpaceflightController,
+  type SpaceflightController,
+  type SpaceflightControllerOptions,
+} from './spaceflight';
 
 type SharedPresetOptions = Omit<
   ThirdPersonControllerOptions,
@@ -48,6 +53,23 @@ type SharedVehiclePresetOptions = Pick<
   VehicleControllerOptions,
   'target' | 'groundY' | 'enabled' | 'bounds'
 >;
+type SpaceflightPresetOptions = Omit<
+  SpaceflightControllerOptions,
+  | 'target'
+  | 'thrust'
+  | 'brakeDeceleration'
+  | 'drag'
+  | 'maxSpeed'
+  | 'strafeSpeed'
+  | 'yawSpeed'
+  | 'pitchSpeed'
+  | 'rollSpeed'
+  | 'autoLevelRoll'
+  | 'cameraDistance'
+  | 'cameraHeight'
+  | 'cameraLerp'
+  | 'focusDistance'
+>;
 
 export interface PresetControllerOptions extends SharedPresetOptions {
   target: Entity;
@@ -56,6 +78,10 @@ export interface PresetControllerOptions extends SharedPresetOptions {
 export interface VehiclePresetControllerOptions
   extends SharedVehiclePresetOptions,
     VehiclePresetOptions {}
+
+export interface SpaceflightPresetControllerOptions extends SpaceflightPresetOptions {
+  target: Entity;
+}
 
 export type ControllerPresetKind =
   | 'firstPerson'
@@ -66,6 +92,7 @@ export type ControllerPresetKind =
   | 'sideScroller2D'
   | 'vehicleArcade'
   | 'vehicleSim'
+  | 'spaceflightArcade'
   | 'railCamera'
   | 'strategyFreeCam';
 
@@ -78,9 +105,15 @@ export const CONTROLLER_PRESET_KINDS: ControllerPresetKind[] = [
   'sideScroller2D',
   'vehicleArcade',
   'vehicleSim',
+  'spaceflightArcade',
   'railCamera',
   'strategyFreeCam',
 ];
+
+export type PresetController =
+  | ThirdPersonController
+  | VehicleController
+  | SpaceflightController;
 
 export function createFirstPersonController(
   game: Game,
@@ -272,6 +305,28 @@ export function createVehicleSimController(
   });
 }
 
+export function createSpaceflightArcadeController(
+  game: Game,
+  options: SpaceflightPresetControllerOptions,
+): SpaceflightController {
+  return createSpaceflightController(game, {
+    thrust: 22,
+    brakeDeceleration: 30,
+    drag: 0.65,
+    maxSpeed: 24,
+    strafeSpeed: 8.5,
+    yawSpeed: 1.85,
+    pitchSpeed: 1.45,
+    rollSpeed: 2.2,
+    autoLevelRoll: 1.25,
+    cameraDistance: 11,
+    cameraHeight: 2.2,
+    cameraLerp: 9,
+    focusDistance: 7,
+    ...options,
+  });
+}
+
 export function createRailCameraController(
   game: Game,
   options: PresetControllerOptions,
@@ -322,28 +377,36 @@ export function createStrategyFreeCamController(
 export function createControllerPreset(
   game: Game,
   kind: ControllerPresetKind,
-  options: PresetControllerOptions,
-): ThirdPersonController {
+  options:
+    | PresetControllerOptions
+    | VehiclePresetControllerOptions
+    | SpaceflightPresetControllerOptions,
+): PresetController {
   switch (kind) {
     case 'firstPerson':
-      return createFirstPersonController(game, options);
+      return createFirstPersonController(game, options as PresetControllerOptions);
     case 'thirdPersonOrbit':
-      return createThirdPersonOrbitController(game, options);
+      return createThirdPersonOrbitController(game, options as PresetControllerOptions);
     case 'thirdPersonOverShoulder':
-      return createThirdPersonOverShoulderController(game, options);
+      return createThirdPersonOverShoulderController(game, options as PresetControllerOptions);
     case 'topDown':
-      return createTopDownController(game, options);
+      return createTopDownController(game, options as PresetControllerOptions);
     case 'isometric':
-      return createIsometricController(game, options);
+      return createIsometricController(game, options as PresetControllerOptions);
     case 'sideScroller2D':
-      return createSideScroller2DController(game, options);
+      return createSideScroller2DController(game, options as PresetControllerOptions);
     case 'vehicleArcade':
-      return createVehicleArcadeController(game, options);
+      return createVehicleArcadeController(game, options as VehiclePresetControllerOptions);
     case 'vehicleSim':
-      return createVehicleSimController(game, options);
+      return createVehicleSimController(game, options as VehiclePresetControllerOptions);
+    case 'spaceflightArcade':
+      return createSpaceflightArcadeController(
+        game,
+        options as SpaceflightPresetControllerOptions,
+      );
     case 'railCamera':
-      return createRailCameraController(game, options);
+      return createRailCameraController(game, options as PresetControllerOptions);
     case 'strategyFreeCam':
-      return createStrategyFreeCamController(game, options);
+      return createStrategyFreeCamController(game, options as PresetControllerOptions);
   }
 }

--- a/packages/gameplay/src/spaceflight.ts
+++ b/packages/gameplay/src/spaceflight.ts
@@ -1,0 +1,232 @@
+import type { Entity, Vec3, World } from '@mochi/core';
+
+import {
+  DEFAULT_SPACEFLIGHT_INPUT_BINDINGS,
+  isBindingDown,
+  type SpaceflightInputBindings,
+} from './bindings';
+import type { Game } from './game';
+
+export interface SpaceflightControllerOptions {
+  target: Entity;
+  thrust?: number;
+  brakeDeceleration?: number;
+  drag?: number;
+  maxSpeed?: number;
+  strafeSpeed?: number;
+  yawSpeed?: number;
+  pitchSpeed?: number;
+  rollSpeed?: number;
+  autoLevelRoll?: number;
+  cameraDistance?: number;
+  cameraHeight?: number;
+  cameraLerp?: number;
+  focusDistance?: number;
+  input?: Partial<SpaceflightInputBindings>;
+  enabled?: () => boolean;
+  bounds?: {
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+    minZ: number;
+    maxZ: number;
+  };
+}
+
+export interface SpaceflightController {
+  readonly velocity: Vec3;
+  dispose(): void;
+  reset(): void;
+  getSpeed(): number;
+}
+
+export function createSpaceflightController(
+  game: Game,
+  options: SpaceflightControllerOptions,
+): SpaceflightController {
+  const target = options.target;
+  const thrust = options.thrust ?? 18;
+  const brakeDeceleration = options.brakeDeceleration ?? 22;
+  const drag = options.drag ?? 0.85;
+  const maxSpeed = options.maxSpeed ?? 18;
+  const strafeSpeed = options.strafeSpeed ?? 7;
+  const yawSpeed = options.yawSpeed ?? 1.6;
+  const pitchSpeed = options.pitchSpeed ?? 1.25;
+  const rollSpeed = options.rollSpeed ?? 1.8;
+  const autoLevelRoll = options.autoLevelRoll ?? 1.4;
+  const cameraDistance = options.cameraDistance ?? 10;
+  const cameraHeight = options.cameraHeight ?? 2.4;
+  const cameraLerp = options.cameraLerp ?? 8;
+  const focusDistance = options.focusDistance ?? 5.5;
+  const inputBindings = {
+    ...DEFAULT_SPACEFLIGHT_INPUT_BINDINGS,
+    ...options.input,
+  };
+  const startPosition = { ...target.transform.position };
+  const startRotation = { ...target.transform.rotation };
+  const velocity = { x: 0, y: 0, z: 0 };
+
+  const unsubscribe = game.onFrame(({ delta, input, world }) => {
+    const canMove = options.enabled?.() ?? true;
+
+    if (canMove) {
+      const yaw =
+        Number(isBindingDown(input, inputBindings.yawRight)) -
+        Number(isBindingDown(input, inputBindings.yawLeft));
+      const pitch =
+        Number(isBindingDown(input, inputBindings.pitchDown)) -
+        Number(isBindingDown(input, inputBindings.pitchUp));
+      const roll =
+        Number(isBindingDown(input, inputBindings.rollRight)) -
+        Number(isBindingDown(input, inputBindings.rollLeft));
+      const throttle =
+        Number(isBindingDown(input, inputBindings.thrust)) -
+        Number(isBindingDown(input, inputBindings.brake));
+      const vertical =
+        Number(isBindingDown(input, inputBindings.strafeUp)) -
+        Number(isBindingDown(input, inputBindings.strafeDown));
+
+      target.transform.rotation.y += yaw * yawSpeed * delta;
+      target.transform.rotation.x = clamp(
+        target.transform.rotation.x + pitch * pitchSpeed * delta,
+        -Math.PI * 0.46,
+        Math.PI * 0.46,
+      );
+      target.transform.rotation.z += roll * rollSpeed * delta;
+
+      if (roll === 0 && autoLevelRoll > 0) {
+        target.transform.rotation.z = moveToward(
+          target.transform.rotation.z,
+          0,
+          autoLevelRoll * delta,
+        );
+      }
+
+      const forward = getForward(target);
+      if (throttle > 0) {
+        velocity.x += forward.x * thrust * delta;
+        velocity.y += forward.y * thrust * delta;
+        velocity.z += forward.z * thrust * delta;
+      } else if (throttle < 0) {
+        velocity.x = moveToward(velocity.x, 0, brakeDeceleration * delta);
+        velocity.y = moveToward(velocity.y, 0, brakeDeceleration * delta);
+        velocity.z = moveToward(velocity.z, 0, brakeDeceleration * delta);
+      }
+
+      velocity.y += vertical * strafeSpeed * delta;
+      clampVelocity(velocity, maxSpeed);
+    }
+
+    velocity.x = applyDrag(velocity.x, drag, delta);
+    velocity.y = applyDrag(velocity.y, drag, delta);
+    velocity.z = applyDrag(velocity.z, drag, delta);
+
+    target.transform.position.x += velocity.x * delta;
+    target.transform.position.y += velocity.y * delta;
+    target.transform.position.z += velocity.z * delta;
+    clampToBounds();
+    updateCamera(world, delta);
+  });
+
+  return {
+    velocity,
+    dispose: unsubscribe,
+    reset() {
+      velocity.x = 0;
+      velocity.y = 0;
+      velocity.z = 0;
+      target.transform.position.x = startPosition.x;
+      target.transform.position.y = startPosition.y;
+      target.transform.position.z = startPosition.z;
+      target.transform.rotation.x = startRotation.x;
+      target.transform.rotation.y = startRotation.y;
+      target.transform.rotation.z = startRotation.z;
+    },
+    getSpeed() {
+      return Math.hypot(velocity.x, velocity.y, velocity.z);
+    },
+  };
+
+  function clampToBounds(): void {
+    if (!options.bounds) return;
+
+    target.transform.position.x = clamp(
+      target.transform.position.x,
+      options.bounds.minX,
+      options.bounds.maxX,
+    );
+    target.transform.position.y = clamp(
+      target.transform.position.y,
+      options.bounds.minY,
+      options.bounds.maxY,
+    );
+    target.transform.position.z = clamp(
+      target.transform.position.z,
+      options.bounds.minZ,
+      options.bounds.maxZ,
+    );
+  }
+
+  function updateCamera(world: World, delta: number): void {
+    const forward = getForward(target);
+    const focus = {
+      x: target.transform.position.x + forward.x * focusDistance,
+      y: target.transform.position.y + forward.y * focusDistance,
+      z: target.transform.position.z + forward.z * focusDistance,
+    };
+    const desired = {
+      x: target.transform.position.x - forward.x * cameraDistance,
+      y: target.transform.position.y - forward.y * cameraDistance + cameraHeight,
+      z: target.transform.position.z - forward.z * cameraDistance,
+    };
+    const amount = 1 - Math.exp(-cameraLerp * delta);
+
+    world.camera.position.x += (desired.x - world.camera.position.x) * amount;
+    world.camera.position.y += (desired.y - world.camera.position.y) * amount;
+    world.camera.position.z += (desired.z - world.camera.position.z) * amount;
+    world.camera.target.x += (focus.x - world.camera.target.x) * amount;
+    world.camera.target.y += (focus.y - world.camera.target.y) * amount;
+    world.camera.target.z += (focus.z - world.camera.target.z) * amount;
+  }
+}
+
+export function getSpaceflightForward(entity: Entity): Vec3 {
+  return getForward(entity);
+}
+
+function getForward(entity: Entity): Vec3 {
+  const pitch = entity.transform.rotation.x;
+  const yaw = entity.transform.rotation.y;
+  const cosPitch = Math.cos(pitch);
+
+  return {
+    x: Math.sin(yaw) * cosPitch,
+    y: -Math.sin(pitch),
+    z: -Math.cos(yaw) * cosPitch,
+  };
+}
+
+function applyDrag(value: number, drag: number, delta: number): number {
+  return value * Math.max(0, 1 - drag * delta);
+}
+
+function clampVelocity(velocity: Vec3, maxSpeed: number): void {
+  const speed = Math.hypot(velocity.x, velocity.y, velocity.z);
+  if (speed <= maxSpeed || speed === 0) return;
+
+  const scale = maxSpeed / speed;
+  velocity.x *= scale;
+  velocity.y *= scale;
+  velocity.z *= scale;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function moveToward(value: number, target: number, amount: number): number {
+  if (value < target) return Math.min(target, value + amount);
+  if (value > target) return Math.max(target, value - amount);
+  return target;
+}

--- a/packages/gameplay/test/presets.test.ts
+++ b/packages/gameplay/test/presets.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import {
   CONTROLLER_PRESET_KINDS,
   createControllerPreset,
+  createSpaceflightArcadeController,
   createThirdPersonController,
   createThirdPersonOrbitController,
   createVehicleArcadeController,
@@ -21,7 +22,7 @@ describe('controller presets', () => {
       controller.dispose();
     }
 
-    assert.equal(CONTROLLER_PRESET_KINDS.length, 10);
+    assert.equal(CONTROLLER_PRESET_KINDS.length, 11);
   });
 
   it('moves third-person targets from configured input bindings', () => {
@@ -81,5 +82,28 @@ describe('controller presets', () => {
     assert.equal(controller.getSpeed(), 0);
     assert.deepEqual(target.transform.position, { x: 0, y: 0, z: 0 });
     assert.equal(target.transform.rotation.y, 0);
+  });
+
+  it('flies spaceflight controllers in open 3D space', () => {
+    const game = createHeadlessGame();
+    const target = game.world.createEntity({ id: 'ship' });
+    const controller = createSpaceflightArcadeController(game, { target });
+
+    game.runtime.inputWriter.setKey('KeyW', true);
+    game.runtime.inputWriter.setKey('KeyD', true);
+    game.runtime.inputWriter.setKey('Space', true);
+    game.runtime.tick(0.25);
+
+    assert.ok(controller.getSpeed() > 0);
+    assert.ok(target.transform.position.y > 0);
+    assert.ok(target.transform.position.z < 0);
+    assert.ok(target.transform.rotation.y > 0);
+
+    controller.reset();
+
+    assert.equal(controller.getSpeed(), 0);
+    assert.deepEqual(controller.velocity, { x: 0, y: 0, z: 0 });
+    assert.deepEqual(target.transform.position, { x: 0, y: 0, z: 0 });
+    assert.deepEqual(target.transform.rotation, { x: 0, y: 0, z: 0 });
   });
 });


### PR DESCRIPTION
## Summary
- add a reusable spaceflight arcade controller with thrust, pitch, yaw, roll, vertical strafe, velocity, bounds, and chase camera support
- add the spaceflight preset to the controller registry and Preset Lab
- add Starfield Drift as a playable spaceflight playground demo
- document the new preset, roadmap progress, and PR version-impact expectations
- ignore local Vite dev logs and .env files

## Verification
- pnpm verify
- pnpm version:check
- dev server responded with HTTP 200 at localhost during local sanity check

## Version impact
- Minor - adds a backward-compatible public controller preset/API and a new playable demo.
