### PR TITLE
Add projectile emitter gameplay helper

### DIFF
--- a/apps/playground/src/demos/StarfieldDriftDemo.vue
+++ b/apps/playground/src/demos/StarfieldDriftDemo.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { useGame } from '@mochi/vue';
 import {
+  createProjectileEmitter,
   createSpaceflightArcadeController,
   getSpaceflightForward,
   type Entity,
+  type ProjectileTarget,
 } from '@mochi/gameplay';
 import { computed, onBeforeUnmount, shallowRef } from 'vue';
 import DemoHud from '../components/DemoHud.vue';
@@ -15,9 +17,17 @@ interface Beacon {
   phase: number;
 }
 
+interface Drone {
+  entity: Entity;
+  destroyed: boolean;
+  baseScale: number;
+  phase: number;
+}
+
 const game = useGame();
 const scene = game.createScene();
 const beaconsCollected = shallowRef(0);
+const dronesDestroyed = shallowRef(0);
 const missionState = shallowRef<'running' | 'complete'>('running');
 const speed = shallowRef(0);
 const altitude = shallowRef(0);
@@ -62,6 +72,12 @@ const beacons: Beacon[] = [
   createBeacon('beacon-4', 8.5, 4.8, -41, 1.05, 3.5),
   createBeacon('beacon-5', 0, 7.4, -54, 1.1, 4.4),
 ];
+const drones: Drone[] = [
+  createDrone('drone-1', 5.5, 4.8, -12, 0),
+  createDrone('drone-2', -6.5, 7.2, -26, 1.4),
+  createDrone('drone-3', 7.5, 5.4, -38, 2.6),
+  createDrone('drone-4', -4, 9.2, -50, 3.7),
+];
 
 for (let i = 0; i < 72; i += 1) {
   const lane = (i % 9) - 4;
@@ -97,28 +113,50 @@ const controller = createSpaceflightArcadeController(game, {
   bounds: { minX: -16, maxX: 16, minY: 0.8, maxY: 14, minZ: -62, maxZ: 14 },
 });
 scene.add(controller);
+
+const blasters = createProjectileEmitter({
+  scene,
+  idPrefix: 'drift-blaster',
+  maxProjectiles: 18,
+  speed: 42,
+  lifetime: 1.25,
+  radius: 0.28,
+  size: 0.16,
+  color: { x: 0.55, y: 0.95, z: 1 },
+  targets: () => droneTargets(),
+});
+scene.add(blasters);
+
+let fireCooldown = 0;
 scene.addReset(() => {
   beaconsCollected.value = 0;
+  dronesDestroyed.value = 0;
   missionState.value = 'running';
+  fireCooldown = 0;
   controller.reset();
 
   for (const beacon of beacons) {
     beacon.collected = false;
+  }
+
+  for (const drone of drones) {
+    drone.destroyed = false;
   }
 });
 
 const label = computed(() => {
   const status =
     missionState.value === 'complete'
-      ? 'route complete'
-      : `${beaconsCollected.value}/${beacons.length} beacons`;
+      ? 'sector clear'
+      : `${beaconsCollected.value}/${beacons.length} beacons  |  ${dronesDestroyed.value}/${drones.length} drones`;
   return `${status}  |  ${speed.value.toFixed(1)} m/s  |  altitude ${altitude.value.toFixed(1)}`;
 });
 
-scene.onFrame(({ delta, elapsed }) => {
+scene.onFrame(({ delta, elapsed, input }) => {
   speed.value = controller.getSpeed();
   altitude.value = ship.transform.position.y;
   syncShipParts();
+  fireCooldown = Math.max(0, fireCooldown - delta);
 
   const flame = 0.7 + Math.sin(elapsed * 18) * 0.25 + Math.min(speed.value / 24, 1) * 0.55;
   engineGlow.transform.scale.z = 0.24 * flame;
@@ -136,10 +174,27 @@ scene.onFrame(({ delta, elapsed }) => {
     if (!beacon.collected && distance3d(ship, beacon.entity) < 1.7) {
       beacon.collected = true;
       beaconsCollected.value += 1;
-      if (beaconsCollected.value === beacons.length) {
-        missionState.value = 'complete';
-      }
+      completeMissionIfReady();
     }
+  }
+
+  for (const drone of drones) {
+    drone.entity.transform.rotation.y += delta * (1.4 + drone.phase * 0.1);
+    drone.entity.transform.rotation.x = Math.sin(elapsed * 1.8 + drone.phase) * 0.35;
+    drone.entity.transform.position.y += Math.sin(elapsed * 2 + drone.phase) * 0.004;
+
+    const visibleScale = drone.destroyed ? 0 : drone.baseScale;
+    drone.entity.transform.scale.x = visibleScale;
+    drone.entity.transform.scale.y = visibleScale * 0.65;
+    drone.entity.transform.scale.z = visibleScale;
+  }
+
+  if (
+    missionState.value === 'running' &&
+    fireCooldown === 0 &&
+    (input.isPointerButtonDown(0) || input.wasKeyPressed('KeyX'))
+  ) {
+    fireBlaster();
   }
 });
 
@@ -195,6 +250,56 @@ function createBeacon(
   };
 }
 
+function createDrone(id: string, x: number, y: number, z: number, phase: number): Drone {
+  const baseScale = 0.85;
+  return {
+    entity: createBox(id, x, y, z, baseScale, baseScale * 0.65, baseScale, {
+      x: 1,
+      y: 0.34,
+      z: 0.28,
+    }),
+    destroyed: false,
+    baseScale,
+    phase,
+  };
+}
+
+function droneTargets(): ProjectileTarget[] {
+  return drones.map((drone) => ({
+    entity: drone.entity,
+    radius: 1,
+    active: () => !drone.destroyed,
+    onHit: () => {
+      if (drone.destroyed) return;
+      drone.destroyed = true;
+      dronesDestroyed.value += 1;
+      completeMissionIfReady();
+    },
+  }));
+}
+
+function fireBlaster(): void {
+  const forward = getSpaceflightForward(ship);
+  blasters.fire({
+    position: {
+      x: nose.transform.position.x + forward.x * 0.5,
+      y: nose.transform.position.y + forward.y * 0.5,
+      z: nose.transform.position.z + forward.z * 0.5,
+    },
+    direction: forward,
+  });
+  fireCooldown = 0.16;
+}
+
+function completeMissionIfReady(): void {
+  if (
+    beaconsCollected.value === beacons.length &&
+    dronesDestroyed.value === drones.length
+  ) {
+    missionState.value = 'complete';
+  }
+}
+
 function createBox(
   id: string,
   x: number,
@@ -230,6 +335,6 @@ function distance3d(a: Entity, b: Entity): number {
   <DemoHud
     mode="STARFIELD DRIFT"
     :title="label"
-    hint="W thrust. S brake. A/D yaw. R/F pitch. Q/E roll. Space/Shift strafe vertically."
+    hint="W thrust. S brake. A/D yaw. R/F pitch. Q/E roll. Space/Shift strafe vertically. Left click or X fires."
   />
 </template>

--- a/docs/PRESET_GUIDE.md
+++ b/docs/PRESET_GUIDE.md
@@ -92,6 +92,29 @@ const bodies = queryCollisionBodies(game.world.allEntities());
 const triggerPairs = queryTriggerPairs(bodies);
 ```
 
+### Projectiles
+
+```ts
+import { createProjectileEmitter, getSpaceflightForward } from '@mochi/gameplay';
+
+const blasters = createProjectileEmitter({
+  scene,
+  targets: () => enemies.map((enemy) => ({
+    entity: enemy.entity,
+    radius: 1,
+    active: () => !enemy.destroyed,
+    onHit: () => {
+      enemy.destroyed = true;
+    },
+  })),
+});
+
+blasters.fire({
+  position: ship.transform.position,
+  direction: getSpaceflightForward(ship),
+});
+```
+
 ### Vue HUD stats
 
 ```ts
@@ -183,6 +206,7 @@ const controller = createSpaceflightArcadeController(game, {
 - In vehicle presets, `forward` and `backward` map to throttle and brake.
 - For vehicle presets, tune `acceleration`, `maxSpeed`, `drag`, and `turnSpeed`.
 - In spaceflight presets, tune `thrust`, `maxSpeed`, `drag`, pitch/yaw/roll speeds, and 3D bounds.
+- Use pooled projectile emitters for repeated blaster-style firing rather than creating unbounded entities per shot.
 - Tune sensitivity and camera lerp before adding special logic.
 - Keep defaults unless you have a clear gameplay reason.
 - Add a new preset only if multiple projects need the same tuned profile.

--- a/docs/PROJECT_LAYOUT.md
+++ b/docs/PROJECT_LAYOUT.md
@@ -33,6 +33,15 @@ src/
 
 Keep gameplay state in engine/runtime structures; keep Vue focused on presentation and player-facing controls.
 
+## Engine vs game code
+
+Treat `packages/*` as the engine that external developers install and build against. Treat `apps/playground` as a consumer of that public API.
+
+- Demos should be written like external game code whenever possible.
+- Demo-specific mission rules, enemy behavior, scoring, layout, and UI should stay in the demo/app layer.
+- Promote code into `packages/gameplay` only when it is a reusable engine primitive with a clear public API.
+- If a demo needs a new engine feature, make that as a separate, reviewable engine change and keep the demo as an example of using it.
+
 ## Scene lifecycle pattern
 
 1. Create entities

--- a/docs/RECENT_CHANGES.md
+++ b/docs/RECENT_CHANGES.md
@@ -16,6 +16,7 @@ This recap covers the latest engine and playground work after the initial core/r
 - Added simple material presets and `createMaterial()` for current solid-color rendering.
 - Reworked `vehicleArcade` and `vehicleSim` to use vehicle-style throttle, braking, steering, drag, and chase camera behavior instead of character-style movement.
 - Added `spaceflightArcade`, a spacecraft controller preset for open 3D movement with thrust, pitch, yaw, roll, vertical strafe, velocity readout, and chase camera behavior.
+- Added pooled projectile emitters with lifetime, target hit callbacks, hit signals, and scene reset integration.
 
 ## Rendering
 
@@ -34,6 +35,7 @@ This recap covers the latest engine and playground work after the initial core/r
 - Added `First Person Range`, a dedicated `firstPerson` demo with signal collection, a timer, and reset support.
 - Added `Tactics Board`, an `isometric` demo with blockers, capture zones, and reset support.
 - Added `Starfield Drift`, a small spaceflight demo with beacons, asteroids, starfield markers, and ship HUD telemetry.
+- Updated `Starfield Drift` with blaster fire, shootable drone targets, and combined beacon/drone mission completion.
 - Added a `Tactics Board` debug toggle for showing blocker collision bounds and the controlled unit target.
 - Updated `Velocity Circuit` to show speed and use the new vehicle controller feel.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-This roadmap is intentionally practical. The long-term goal is a full-featured, AAA-capable web game engine that can be used by anyone, while the near-term work stays grounded in playable vertical slices.
+This roadmap is intentionally practical. The long-term goal is a full-featured, AAA-capable web game engine that can stand beside Unity, Godot, and Unreal as a serious option for modern web developers, while the near-term work stays grounded in playable vertical slices.
 
 ## North star
 
@@ -15,6 +15,8 @@ Mochi should eventually provide the kinds of systems expected from a serious gam
 - approachable APIs and templates for solo developers and teams
 
 The engine should not become complex by default. AAA-level capability should be layered behind simple entry points.
+
+Mochi is web-native first: it should feel natural inside Vue and other modern frontend stacks, but the engine core must stay framework-agnostic enough for React, Svelte, vanilla TypeScript, and non-DOM runtimes to build on it. Demos are proof points for external developers, not special cases that require editing the engine.
 
 ## Current status
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,6 +58,7 @@ The engine should not become complex by default. AAA-level capability should be 
 - [x] Add collision/world helper APIs promoted from playground patterns.
 - [x] Add reset/replay helpers for demos and small games.
 - [x] Add input binding config (`WASD`, arrows, gamepad-ready shape).
+- [x] Add pooled projectile helpers for simple combat loops.
 
 ### Vue layer
 
@@ -117,6 +118,7 @@ The engine should not become complex by default. AAA-level capability should be 
 - [ ] Promote collision helpers into reusable engine primitives.
 - [ ] Add character controller foundations.
 - [ ] Add trigger volumes, hitboxes, and damage zones.
+- [x] Add first reusable projectile emitter for blaster-style interactions.
 - [ ] Add physics backend decision when simple collision is no longer enough.
 
 ### Tools and developer experience

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,9 +26,9 @@ The engine should not become complex by default. AAA-level capability should be 
 - Playground has multiple demos:
   - `Nightfall Run`
   - `Orbital Islands`
-- `Velocity Circuit`
-- `Starfield Drift`
-- `Preset Lab`
+  - `Velocity Circuit`
+  - `Starfield Drift`
+  - `Preset Lab`
   - `First Person Range`
   - `Tactics Board`
 
@@ -145,6 +145,7 @@ The engine should not become complex by default. AAA-level capability should be 
 - Keep the default path simple.
 - Preserve lower-level escape hatches.
 - Promote patterns only after they appear in more than one demo.
+- Keep demos as examples of public engine usage, not as hidden requirements for engine modification.
 - Avoid framework coupling in runtime and renderer.
 - Build demos that feel playable, not just technically correct.
 - Grow toward AAA capability through staged systems, not speculative rewrites.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "pnpm --filter playground dev",
     "build": "pnpm --filter playground build",
-    "test": "node --import tsx --test packages/core/test/collision.test.ts packages/core/test/input-runtime.test.ts packages/core/test/math.test.ts packages/gameplay/test/presets.test.ts packages/gameplay/test/scene.test.ts",
+    "test": "node --import tsx --test packages/core/test/collision.test.ts packages/core/test/input-runtime.test.ts packages/core/test/math.test.ts packages/gameplay/test/presets.test.ts packages/gameplay/test/projectiles.test.ts packages/gameplay/test/scene.test.ts",
     "version:bump": "node scripts/bump-version.mjs",
     "version:check": "node scripts/bump-version.mjs --check",
     "typecheck": "pnpm -r --workspace-concurrency=1 --if-present typecheck && pnpm exec tsc -p tsconfig.test.json --noEmit",

--- a/packages/gameplay/src/index.ts
+++ b/packages/gameplay/src/index.ts
@@ -83,6 +83,15 @@ export {
   type SpaceflightControllerOptions,
 } from './spaceflight';
 export {
+  createProjectileEmitter,
+  type Projectile,
+  type ProjectileEmitter,
+  type ProjectileEmitterOptions,
+  type ProjectileFireOptions,
+  type ProjectileHit,
+  type ProjectileTarget,
+} from './projectiles';
+export {
   createVehicleController,
   type VehicleController,
   type VehicleControllerOptions,

--- a/packages/gameplay/src/projectiles.ts
+++ b/packages/gameplay/src/projectiles.ts
@@ -1,0 +1,208 @@
+import type { Entity, Vec3 } from '@mochi/core';
+
+import { createEventSignal, type EventSignal } from './events';
+import type { GameScene } from './scene';
+
+export interface ProjectileTarget {
+  entity: Entity;
+  radius?: number;
+  active?: () => boolean;
+  onHit?: (hit: ProjectileHit) => void;
+}
+
+export interface ProjectileHit {
+  projectile: Projectile;
+  target: ProjectileTarget;
+}
+
+export interface Projectile {
+  readonly entity: Entity;
+  readonly velocity: Vec3;
+  active: boolean;
+  age: number;
+  lifetime: number;
+  radius: number;
+}
+
+export interface ProjectileFireOptions {
+  position: Vec3;
+  direction: Vec3;
+  speed?: number;
+  lifetime?: number;
+  radius?: number;
+}
+
+export interface ProjectileEmitterOptions {
+  scene: GameScene;
+  idPrefix?: string;
+  maxProjectiles?: number;
+  speed?: number;
+  lifetime?: number;
+  radius?: number;
+  size?: number;
+  color?: Vec3;
+  targets?: () => readonly ProjectileTarget[];
+}
+
+export interface ProjectileEmitter {
+  readonly projectiles: readonly Projectile[];
+  readonly hits: EventSignal<ProjectileHit>;
+  fire(options: ProjectileFireOptions): Projectile | null;
+  reset(): void;
+  dispose(): void;
+}
+
+export function createProjectileEmitter(
+  options: ProjectileEmitterOptions,
+): ProjectileEmitter {
+  const scene = options.scene;
+  const maxProjectiles = options.maxProjectiles ?? 24;
+  const defaultSpeed = options.speed ?? 34;
+  const defaultLifetime = options.lifetime ?? 1.4;
+  const defaultRadius = options.radius ?? 0.35;
+  const size = options.size ?? 0.18;
+  const color = options.color ?? { x: 0.35, y: 0.9, z: 1 };
+  const hits = createEventSignal<ProjectileHit>();
+  const projectiles: Projectile[] = [];
+
+  for (let index = 0; index < maxProjectiles; index += 1) {
+    const entity = scene.createEntity({
+      id: `${options.idPrefix ?? 'projectile'}-${index}`,
+      transform: {
+        position: { x: 0, y: -9999, z: 0 },
+        scale: { x: 0, y: 0, z: 0 },
+      },
+      renderable: {
+        primitive: 'cube',
+        material: { color: { ...color } },
+      },
+    });
+
+    projectiles.push({
+      entity,
+      velocity: { x: 0, y: 0, z: 0 },
+      active: false,
+      age: 0,
+      lifetime: defaultLifetime,
+      radius: defaultRadius,
+    });
+  }
+
+  const unsubscribe = scene.onFrame(({ delta }) => {
+    const targets = options.targets?.() ?? [];
+
+    for (const projectile of projectiles) {
+      if (!projectile.active) continue;
+
+      projectile.age += delta;
+      projectile.entity.transform.position.x += projectile.velocity.x * delta;
+      projectile.entity.transform.position.y += projectile.velocity.y * delta;
+      projectile.entity.transform.position.z += projectile.velocity.z * delta;
+
+      if (projectile.age >= projectile.lifetime) {
+        deactivate(projectile);
+        continue;
+      }
+
+      const hitTarget = findHitTarget(projectile, targets);
+      if (hitTarget) {
+        const hit = { projectile, target: hitTarget };
+        hitTarget.onHit?.(hit);
+        hits.emit(hit);
+        deactivate(projectile);
+      }
+    }
+  });
+
+  scene.addReset(reset);
+
+  return {
+    projectiles,
+    hits,
+    fire(options) {
+      const direction = normalize(options.direction);
+      if (!direction) return null;
+
+      const projectile = projectiles.find((candidate) => !candidate.active);
+      if (!projectile) return null;
+
+      const speed = options.speed ?? defaultSpeed;
+      projectile.active = true;
+      projectile.age = 0;
+      projectile.lifetime = options.lifetime ?? defaultLifetime;
+      projectile.radius = options.radius ?? defaultRadius;
+      projectile.velocity.x = direction.x * speed;
+      projectile.velocity.y = direction.y * speed;
+      projectile.velocity.z = direction.z * speed;
+      projectile.entity.transform.position.x = options.position.x;
+      projectile.entity.transform.position.y = options.position.y;
+      projectile.entity.transform.position.z = options.position.z;
+      projectile.entity.transform.rotation.x = Math.asin(-direction.y);
+      projectile.entity.transform.rotation.y = Math.atan2(direction.x, -direction.z);
+      projectile.entity.transform.rotation.z = 0;
+      projectile.entity.transform.scale.x = size;
+      projectile.entity.transform.scale.y = size;
+      projectile.entity.transform.scale.z = size * 2.8;
+
+      return projectile;
+    },
+    reset,
+    dispose() {
+      unsubscribe();
+      hits.clear();
+    },
+  };
+
+  function reset(): void {
+    for (const projectile of projectiles) {
+      deactivate(projectile);
+    }
+    hits.clear();
+  }
+}
+
+function findHitTarget(
+  projectile: Projectile,
+  targets: readonly ProjectileTarget[],
+): ProjectileTarget | null {
+  for (const target of targets) {
+    if (target.active && !target.active()) continue;
+
+    const radius = target.radius ?? 0.75;
+    if (distance3d(projectile.entity, target.entity) <= projectile.radius + radius) {
+      return target;
+    }
+  }
+
+  return null;
+}
+
+function deactivate(projectile: Projectile): void {
+  projectile.active = false;
+  projectile.age = 0;
+  projectile.velocity.x = 0;
+  projectile.velocity.y = 0;
+  projectile.velocity.z = 0;
+  projectile.entity.transform.position.y = -9999;
+  projectile.entity.transform.scale.x = 0;
+  projectile.entity.transform.scale.y = 0;
+  projectile.entity.transform.scale.z = 0;
+}
+
+function normalize(vector: Vec3): Vec3 | null {
+  const length = Math.hypot(vector.x, vector.y, vector.z);
+  if (length === 0) return null;
+
+  return {
+    x: vector.x / length,
+    y: vector.y / length,
+    z: vector.z / length,
+  };
+}
+
+function distance3d(a: Entity, b: Entity): number {
+  const dx = a.transform.position.x - b.transform.position.x;
+  const dy = a.transform.position.y - b.transform.position.y;
+  const dz = a.transform.position.z - b.transform.position.z;
+  return Math.hypot(dx, dy, dz);
+}

--- a/packages/gameplay/test/projectiles.test.ts
+++ b/packages/gameplay/test/projectiles.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createProjectileEmitter, type ProjectileHit } from '../src';
+import { createHeadlessGame } from './headlessGame';
+
+describe('projectile emitters', () => {
+  it('fires pooled projectiles and expires them after their lifetime', () => {
+    const game = createHeadlessGame();
+    const scene = game.createScene();
+    const emitter = createProjectileEmitter({
+      scene,
+      maxProjectiles: 1,
+      speed: 10,
+      lifetime: 0.2,
+    });
+
+    const projectile = emitter.fire({
+      position: { x: 0, y: 0, z: 0 },
+      direction: { x: 0, y: 0, z: -1 },
+    });
+
+    assert.notEqual(projectile, null);
+    assert.equal(projectile?.active, true);
+    game.runtime.tick(0.1);
+    assert.equal(projectile?.entity.transform.position.z, -1);
+    game.runtime.tick(0.11);
+    assert.equal(projectile?.active, false);
+    assert.equal(projectile?.entity.transform.scale.x, 0);
+  });
+
+  it('emits target hits and deactivates projectiles', () => {
+    const game = createHeadlessGame();
+    const scene = game.createScene();
+    const target = scene.createEntity({
+      id: 'target',
+      transform: { position: { x: 0, y: 0, z: -2 } },
+    });
+    const hits: ProjectileHit[] = [];
+    let targetHit = 0;
+    const emitter = createProjectileEmitter({
+      scene,
+      speed: 10,
+      lifetime: 1,
+      targets: () => [
+        {
+          entity: target,
+          radius: 0.5,
+          onHit: () => {
+            targetHit += 1;
+          },
+        },
+      ],
+    });
+    emitter.hits.on((hit) => hits.push(hit));
+
+    const projectile = emitter.fire({
+      position: { x: 0, y: 0, z: 0 },
+      direction: { x: 0, y: 0, z: -1 },
+      radius: 0.2,
+    });
+    game.runtime.tick(0.2);
+
+    assert.equal(projectile?.active, false);
+    assert.equal(targetHit, 1);
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].target.entity, target);
+  });
+
+  it('resets active projectiles with the scene', () => {
+    const game = createHeadlessGame();
+    const scene = game.createScene();
+    const emitter = createProjectileEmitter({ scene });
+    const projectile = emitter.fire({
+      position: { x: 1, y: 2, z: 3 },
+      direction: { x: 1, y: 0, z: 0 },
+    });
+
+    scene.reset();
+
+    assert.equal(projectile?.active, false);
+    assert.deepEqual(projectile?.velocity, { x: 0, y: 0, z: 0 });
+    assert.equal(projectile?.entity.transform.scale.x, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a pooled projectile emitter helper with lifetime, target hit callbacks, hit signals, scene reset support, and exported types
- add projectile tests covering expiry, hits, and reset behavior
- update Starfield Drift with blaster fire, shootable drone targets, and combined beacon/drone mission completion
- document projectile usage and roadmap progress
- clarify that playground demos should behave like external consumers of the public engine API, with reusable primitives promoted through packages only when they are generic
- clarify Mochi's north star as a web-native engine that can grow toward Unity/Godot/Unreal-level capability while staying natural for frontend framework developers

## Verification
- [x] pnpm verify
- [x] pnpm version:check
- [x] Dev server smoke check returned HTTP 200 at http://127.0.0.1:5174/

## Version impact
- [x] Minor - new backward-compatible public gameplay helper and expanded space demo capability

Reason:
- Exports createProjectileEmitter and related projectile types from @mochi/gameplay, enabling small combat loops without breaking existing APIs.
- The engine/demo boundary and north-star clarifications are docs-only and would not require a version bump by themselves.
