### PR TITLE
Fix release version argument parsing

### DIFF
--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -55,6 +55,10 @@ function parseArgs(argv) {
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index];
 
+    if (arg === '--') {
+      continue;
+    }
+
     if (arg === '--check') {
       parsed.check = true;
       continue;


### PR DESCRIPTION
## Summary
- allow the version bump script to ignore the npm argument separator used by the Prepare Release workflow

## Verification
- pnpm version:check
- node scripts/bump-version.mjs -- --check