### PR TITLE
Release v0.2.0-alpha.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mochi",
-  "version": "0.1.1",
+  "version": "0.2.0-alpha.0",
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mochi-labs/core",
-  "version": "0.1.1",
+  "version": "0.2.0-alpha.0",
   "private": false,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/gameplay/package.json
+++ b/packages/gameplay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mochi-labs/gameplay",
-  "version": "0.1.1",
+  "version": "0.2.0-alpha.0",
   "private": false,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/renderer-webgl/package.json
+++ b/packages/renderer-webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mochi-labs/renderer-webgl",
-  "version": "0.1.1",
+  "version": "0.2.0-alpha.0",
   "private": false,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mochi-labs/vue",
-  "version": "0.1.1",
+  "version": "0.2.0-alpha.0",
   "private": false,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary
- bump package versions to v0.2.0-alpha.0
- update the pnpm lockfile

## Verification
- pnpm verify

## Publish
After merge, run the Publish npm workflow. It will infer the npm dist-tag from v0.2.0-alpha.0.