### PR TITLE
Fix npm dry run workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -75,15 +75,17 @@ jobs:
           publish_package() {
             local package_dir="$1"
             local dry_run_flag=""
+            local provenance_flag="--provenance"
 
             if [[ "${{ inputs.dry_run }}" == "true" ]]; then
               dry_run_flag="--dry-run"
+              provenance_flag=""
             fi
 
             pnpm --dir "${package_dir}" publish \
               --access public \
               --tag "${{ steps.release.outputs.tag }}" \
-              --provenance \
+              ${provenance_flag} \
               ${dry_run_flag}
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ jobs:
         run: |
           VERSION="$(node -p "require('./package.json').version")"
           TAG="v${VERSION}"
+          PRERELEASE_FLAG=""
+
+          if [[ "${VERSION}" == *"-"* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
 
           if git rev-parse "${TAG}" >/dev/null 2>&1; then
             echo "Release ${TAG} already exists."
@@ -37,4 +42,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "${TAG}" -m "${TAG}"
           git push origin "${TAG}"
-          gh release create "${TAG}" --title "${TAG}" --generate-notes
+          gh release create "${TAG}" --title "${TAG}" --generate-notes ${PRERELEASE_FLAG}


### PR DESCRIPTION
## Summary
- omit npm provenance flags during dry-run publishing
- mark future prerelease GitHub releases as prereleases

## Verification
- inspected failed dry-run logs