### PR TITLE
Use npm for package publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -82,11 +82,11 @@ jobs:
               provenance_flag=""
             fi
 
-            pnpm --dir "${package_dir}" publish \
+            (cd "${package_dir}" && npm publish \
               --access public \
               --tag "${{ steps.release.outputs.tag }}" \
               ${provenance_flag} \
-              ${dry_run_flag}
+              ${dry_run_flag})
           }
 
           publish_package packages/core


### PR DESCRIPTION
## Summary
- run npm publish from each package directory instead of using pnpm publish --dir

## Verification
- npm publish --dry-run --tag alpha in packages/core
- git diff --check