### PR TITLE
Publish packed package tarballs

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -76,17 +76,27 @@ jobs:
             local package_dir="$1"
             local dry_run_flag=""
             local provenance_flag="--provenance"
+            local pack_dir="${RUNNER_TEMP}/mochi-packages"
+            local package_file=""
 
             if [[ "${{ inputs.dry_run }}" == "true" ]]; then
               dry_run_flag="--dry-run"
               provenance_flag=""
             fi
 
-            (cd "${package_dir}" && npm publish \
+            mkdir -p "${pack_dir}"
+            package_file="$(pnpm --dir "${package_dir}" pack --json --pack-destination "${pack_dir}" | node -e "let data = ''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => console.log(JSON.parse(data).filename));")"
+
+            if [[ ! -f "${package_file}" ]]; then
+              echo "Package tarball was not created for ${package_dir}."
+              exit 1
+            fi
+
+            npm publish "${package_file}" \
               --access public \
               --tag "${{ steps.release.outputs.tag }}" \
               ${provenance_flag} \
-              ${dry_run_flag})
+              ${dry_run_flag}
           }
 
           publish_package packages/core


### PR DESCRIPTION
## Summary
- pack packages with pnpm before publishing so workspace dependencies are converted to concrete versions
- fail publishing if a package tarball is not produced

## Verification
- pnpm pack confirms package manifests rewrite workspace dependencies
- git diff --check