### PR TITLE
Add trusted publishing package metadata

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,11 @@
   "files": [
     "src"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AndrewR3K/mochi.git",
+    "directory": "packages/core"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/gameplay/package.json
+++ b/packages/gameplay/package.json
@@ -8,6 +8,11 @@
   "files": [
     "src"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AndrewR3K/mochi.git",
+    "directory": "packages/gameplay"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/renderer-webgl/package.json
+++ b/packages/renderer-webgl/package.json
@@ -8,6 +8,11 @@
   "files": [
     "src"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AndrewR3K/mochi.git",
+    "directory": "packages/renderer-webgl"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -8,6 +8,11 @@
   "files": [
     "src"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AndrewR3K/mochi.git",
+    "directory": "packages/vue"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- run npm publish workflow on Node 24 for trusted publishing support
- add repository metadata to every publishable package

## Verification
- pnpm pack for core and gameplay
- inspected packed package metadata
- git diff --check