### PR TITLE
Add Mochi licensing terms

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,125 @@
+# Mochi License
+
+Mochi is licensed under the Functional Source License, Version 1.1, Apache 2.0 Future License (FSL-1.1-ALv2).
+
+Copyright 2026 Andrew R3K and Mochi contributors.
+
+## License Intent
+
+You may use Mochi to build, ship, and sell games, apps, tools, websites, prototypes, internal tools, and client work.
+
+You may not repackage Mochi, a modified Mochi, or a substantially similar engine/toolkit as a competing commercial product or service.
+
+This summary is provided for convenience. The license terms below control.
+
+## Functional Source License, Version 1.1, ALv2 Future License
+
+### Abbreviation
+
+FSL-1.1-ALv2
+
+### Notice
+
+Copyright 2026 Andrew R3K and Mochi contributors.
+
+### Terms and Conditions
+
+#### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+#### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+#### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+#### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+For clarity, Permitted Purposes include building, distributing, hosting, and
+selling games, applications, websites, demos, simulations, and interactive
+experiences made with the Software, provided that you do not make the Software
+itself available as a competing engine, framework, toolkit, editor, SDK, or
+substantially similar product or service.
+
+#### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+#### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+#### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+#### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Entity blueprints instantiate reusable prefab-style hierarchies while keeping ga
 - [First Game in 10 Minutes](docs/FIRST_GAME.md)
 - [Alpha Release](docs/ALPHA_RELEASE.md)
 - [External Developer Workflow](docs/EXTERNAL_DEVELOPER_WORKFLOW.md)
+- [Licensing](docs/LICENSING.md)
 - [Versioning](docs/VERSIONING.md)
 - [Release Process](docs/RELEASE_PROCESS.md)
 - [Public API Reference Direction](docs/API_REFERENCE.md)
@@ -171,3 +172,7 @@ Entity blueprints instantiate reusable prefab-style hierarchies while keeping ga
 ## Project direction
 
 Mochi should be a configuration-first engine where common game styles start from presets instead of one-off rewrites. Advanced systems should be available when a game needs them; simple APIs should stay simple.
+
+## License
+
+Mochi uses the Functional Source License, Version 1.1, Apache 2.0 Future License (FSL-1.1-ALv2). You can build and sell games/apps with Mochi, but you cannot repackage Mochi itself as a competing commercial engine or SDK. See [LICENSE.md](LICENSE.md) and [Licensing](docs/LICENSING.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,24 @@
+# Third-Party Notices
+
+Mochi's source and published packages are licensed under the Mochi license in `LICENSE.md`.
+
+The project also uses third-party software for development, documentation, testing, examples, and peer integration. Those projects remain under their own licenses.
+
+## Direct Runtime and Peer Dependencies
+
+- Vue (`vue`) - MIT License
+
+## Direct Development Dependencies
+
+- TypeScript (`typescript`) - Apache License 2.0
+- Node.js type declarations (`@types/node`) - MIT License
+- tsx (`tsx`) - MIT License
+- VitePress (`vitepress`) - MIT License
+- Vue TypeScript checker (`vue-tsc`) - MIT License
+- Vite Vue plugin (`@vitejs/plugin-vue`) - MIT License
+
+## Notes
+
+Published Mochi packages do not vendor these dependencies. Package consumers should review dependency licenses for the versions they install through their package manager.
+
+This notice is not a replacement for third-party license texts. It is a project-level pointer to the direct third-party software currently used by the repository.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -108,6 +108,7 @@ export default defineConfig({
           { text: 'Roadmap', link: '/ROADMAP' },
           { text: 'Recent Changes', link: '/RECENT_CHANGES' },
           { text: 'Discussions', link: '/DISCUSSIONS' },
+          { text: 'Licensing', link: '/LICENSING' },
         ],
       },
       {
@@ -120,7 +121,7 @@ export default defineConfig({
       },
     ],
     footer: {
-      message: 'Released under the project license.',
+      message: `Released under the <a href="${base}LICENSING">Mochi license</a>.`,
       copyright: 'Copyright © 2026 Mochi contributors',
     },
   },

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -1,0 +1,34 @@
+# Licensing
+
+Mochi uses the Functional Source License, Version 1.1, Apache 2.0 Future License (FSL-1.1-ALv2).
+
+## What this allows
+
+You can use Mochi to build, ship, and sell:
+
+- games
+- apps
+- websites
+- client projects
+- internal tools
+- prototypes
+- simulations
+- interactive experiences
+
+You can modify Mochi for those uses.
+
+## What this does not allow
+
+You cannot take Mochi, a modified Mochi, or a substantially similar derivative and sell or offer it as a competing commercial engine, framework, toolkit, editor, SDK, or hosted engine service.
+
+## Future open-source license
+
+Each version of Mochi converts to Apache License 2.0 two years after that version is made available.
+
+## Full terms
+
+Read the full license in [LICENSE.md](https://github.com/AndrewR3K/mochi/blob/main/LICENSE.md).
+
+## Third-party software
+
+Mochi's published packages do not bundle their development dependencies. The project uses third-party tools and libraries during development, including Vue, VitePress, TypeScript, and related build/test tooling. See [Third-Party Notices](https://github.com/AndrewR3K/mochi/blob/main/THIRD_PARTY_NOTICES.md).

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mochi",
   "version": "0.2.0-alpha.1",
   "private": true,
+  "license": "SEE LICENSE IN LICENSE.md",
   "packageManager": "pnpm@9.15.0",
   "workspaces": [
     "packages/*",

--- a/packages/core/LICENSE.md
+++ b/packages/core/LICENSE.md
@@ -1,0 +1,7 @@
+# Mochi License
+
+This package is part of Mochi and is licensed under the Functional Source License, Version 1.1, Apache 2.0 Future License (FSL-1.1-ALv2).
+
+See the full license terms at:
+
+https://github.com/AndrewR3K/mochi/blob/main/LICENSE.md

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,11 +2,13 @@
   "name": "@mochi-labs/core",
   "version": "0.2.0-alpha.1",
   "private": false,
+  "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "files": [
-    "src"
+    "src",
+    "LICENSE.md"
   ],
   "repository": {
     "type": "git",

--- a/packages/gameplay/LICENSE.md
+++ b/packages/gameplay/LICENSE.md
@@ -1,0 +1,7 @@
+# Mochi License
+
+This package is part of Mochi and is licensed under the Functional Source License, Version 1.1, Apache 2.0 Future License (FSL-1.1-ALv2).
+
+See the full license terms at:
+
+https://github.com/AndrewR3K/mochi/blob/main/LICENSE.md

--- a/packages/gameplay/package.json
+++ b/packages/gameplay/package.json
@@ -2,11 +2,13 @@
   "name": "@mochi-labs/gameplay",
   "version": "0.2.0-alpha.1",
   "private": false,
+  "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "files": [
-    "src"
+    "src",
+    "LICENSE.md"
   ],
   "repository": {
     "type": "git",

--- a/packages/renderer-webgl/LICENSE.md
+++ b/packages/renderer-webgl/LICENSE.md
@@ -1,0 +1,7 @@
+# Mochi License
+
+This package is part of Mochi and is licensed under the Functional Source License, Version 1.1, Apache 2.0 Future License (FSL-1.1-ALv2).
+
+See the full license terms at:
+
+https://github.com/AndrewR3K/mochi/blob/main/LICENSE.md

--- a/packages/renderer-webgl/package.json
+++ b/packages/renderer-webgl/package.json
@@ -2,11 +2,13 @@
   "name": "@mochi-labs/renderer-webgl",
   "version": "0.2.0-alpha.1",
   "private": false,
+  "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "files": [
-    "src"
+    "src",
+    "LICENSE.md"
   ],
   "repository": {
     "type": "git",

--- a/packages/vue/LICENSE.md
+++ b/packages/vue/LICENSE.md
@@ -1,0 +1,7 @@
+# Mochi License
+
+This package is part of Mochi and is licensed under the Functional Source License, Version 1.1, Apache 2.0 Future License (FSL-1.1-ALv2).
+
+See the full license terms at:
+
+https://github.com/AndrewR3K/mochi/blob/main/LICENSE.md

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,11 +2,13 @@
   "name": "@mochi-labs/vue",
   "version": "0.2.0-alpha.1",
   "private": false,
+  "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "files": [
-    "src"
+    "src",
+    "LICENSE.md"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add the Mochi license using FSL-1.1 with Apache-2.0 future conversion
- document permitted commercial use for games/apps while restricting competing engine redistribution
- include license metadata and package-level license files for published packages
- add third-party notices and link licensing from the VitePress sidebar/footer

## Verification
- pnpm version:check
- pnpm pack for core and vue includes LICENSE.md
- pnpm verify

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/legal metadata and packaging `LICENSE.md` inclusion, with no runtime code or API behavior changes.
> 
> **Overview**
> Adds a new project license (`FSL-1.1-ALv2`) via `LICENSE.md`, plus a short `docs/LICENSING.md` explainer and `THIRD_PARTY_NOTICES.md` pointer for dependency licenses.
> 
> Updates the README and VitePress docs navigation/footer to link to licensing information, and sets `license: "SEE LICENSE IN LICENSE.md"` across the workspace and published packages.
> 
> Ensures each published package (`core`, `gameplay`, `renderer-webgl`, `vue`) ships a package-level `LICENSE.md` by adding it to `files` for npm packaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775ce54bbff145dcb5d3e304096c22bf95d8be15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->