### PR TITLE
[codex] Add gameplay debug overlay helper

### DIFF
--- a/apps/playground/src/demos/TacticsBoardDemo.vue
+++ b/apps/playground/src/demos/TacticsBoardDemo.vue
@@ -2,12 +2,9 @@
 import { useGame } from '@mochi-labs/vue';
 import {
   createBoxCollider,
-  createDebugBoxBounds,
-  createDebugRay,
-  createDebugTargetMarker,
+  createDebugOverlay,
   createGameInspectionSnapshot,
   createIsometricController,
-  createSceneScheduler,
   overlapsCollisionBodies,
   resolveBoxCollisions,
   setBoxCollisionBody,
@@ -36,7 +33,6 @@ const timer = shallowRef(70);
 const state = shallowRef<'running' | 'won' | 'lost'>('running');
 const debugBounds = shallowRef(false);
 const inspection = shallowRef(createGameInspectionSnapshot(game));
-const scheduler = createSceneScheduler(scene);
 
 scene.createEntity({
   id: 'tactics-board',
@@ -65,16 +61,21 @@ const blockers: BoxCollider[] = [
   createBlocker('tactics-blocker-b', 4.2, 0.55, 2.2, 1.2, 1.1, 5.2, { x: 0.18, y: 0.2, z: 0.3 }),
   createBlocker('tactics-blocker-c', 0, 0.45, 0, 3.5, 0.9, 1.1, { x: 0.22, y: 0.24, z: 0.36 }),
 ];
-createDebugBoxBounds(scene, blockers, {
+const debugOverlay = createDebugOverlay(scene, {
+  boxes: blockers,
   enabled: () => debugBounds.value,
-});
-createDebugTargetMarker(scene, unit, {
-  enabled: () => debugBounds.value,
-});
-createDebugRay(scene, () => unit.transform.position, () => ({ x: 0, y: 0, z: -1 }), {
-  id: 'tactics-debug-ray',
-  enabled: () => debugBounds.value,
-  length: 3,
+  targets: [unit],
+  rays: [
+    {
+      id: 'tactics-debug-ray',
+      origin: () => unit.transform.position,
+      direction: () => ({ x: 0, y: 0, z: -1 }),
+      length: 3,
+    },
+  ],
+  onSnapshot: (snapshot) => {
+    inspection.value = snapshot;
+  },
 });
 const points: CapturePoint[] = [
   createCapturePoint('capture-a', -7, -6),
@@ -98,8 +99,6 @@ scene.addReset(() => {
     point.secured = false;
   }
 });
-scene.addReset(scheduleInspectionRefresh);
-scheduleInspectionRefresh();
 
 const label = computed(() => {
   if (state.value === 'won') return 'All zones secured';
@@ -209,15 +208,7 @@ function resetBoard(): void {
 
 function toggleDebugBounds(): void {
   debugBounds.value = !debugBounds.value;
-  inspection.value = createGameInspectionSnapshot(game);
-}
-
-function scheduleInspectionRefresh(): void {
-  scheduler.interval(0.25, () => {
-    if (debugBounds.value) {
-      inspection.value = createGameInspectionSnapshot(game);
-    }
-  });
+  inspection.value = debugOverlay.refresh();
 }
 </script>
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -56,7 +56,7 @@ Use gameplay as the default game-facing entry point:
 - scene scheduler
 - entity blueprints
 - asset registry
-- inspection snapshots and debug visuals
+- inspection snapshots, debug visuals, and debug overlays
 
 ## `@mochi-labs/vue`
 

--- a/docs/PRESET_GUIDE.md
+++ b/docs/PRESET_GUIDE.md
@@ -228,16 +228,29 @@ const player = scene.createEntity({
 ### Debug bounds
 
 ```ts
-import { createDebugBoxBounds, createDebugTargetMarker } from '@mochi-labs/gameplay';
+import { createDebugOverlay } from '@mochi-labs/gameplay';
 
-createDebugBoxBounds(scene, colliders, {
+const debugOverlay = createDebugOverlay(scene, {
+  boxes: colliders,
   enabled: () => showDebugBounds.value,
+  targets: [player],
+  rays: [
+    {
+      id: 'aim-ray',
+      origin: () => player.transform.position,
+      direction: () => ({ x: 0, y: 0, z: -1 }),
+      length: 4,
+    },
+  ],
+  onSnapshot: (snapshot) => {
+    debugStats.value = snapshot;
+  },
 });
 
-createDebugTargetMarker(scene, player, {
-  enabled: () => showDebugBounds.value,
-});
+debugOverlay.refresh();
 ```
+
+Use `createDebugOverlay` when a HUD needs visual debug entities and inspection snapshots from one scene-owned helper. Use the lower-level `createDebugBoxBounds`, `createDebugTargetMarker`, and `createDebugRay` helpers when you need to compose a custom overlay yourself.
 
 ### Input bindings
 

--- a/docs/RECENT_CHANGES.md
+++ b/docs/RECENT_CHANGES.md
@@ -23,6 +23,7 @@ This recap covers engine and playground work after the initial core/renderer/gam
 - Added gameplay trigger volumes and damage zones with enter/stay/exit events and interval-based damage callbacks.
 - Added shared collision helpers for box colliders, 2D distance checks, ground height resolution, box collision resolution, and stepped collision movement.
 - Added debug helpers for rendering collider footprints and target markers through scene-owned entities.
+- Added a debug overlay helper that combines scene-owned bounds, target markers, rays, and throttled inspection snapshots for HUDs and editor-style panels.
 - Added typed event signals for small gameplay events like collection, damage, score, and mission state changes.
 - Added configurable keyboard bindings for character and vehicle controllers while keeping WASD/arrows as the default path.
 - Added material presets and `createMaterial()` for current solid-color rendering.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -134,7 +134,7 @@ Mochi is web-native first. It should feel natural inside Vue and other frontend 
 
 ### Tools and developer experience
 
-- [ ] Add visual debug overlays.
+- [x] Add visual debug overlays.
 - [x] Add initial game inspection snapshots for debug overlays and editor panels.
 - [x] Add lifecycle-bound scene scheduling for timers, cooldowns, waves, and debug refreshes.
 - [x] Add prefab-style entity blueprints for reusable hierarchies.

--- a/packages/gameplay/src/debug.ts
+++ b/packages/gameplay/src/debug.ts
@@ -1,6 +1,10 @@
-import type { Entity, Vec3 } from '@mochi-labs/core';
+import type { Entity, FrameContext, Vec3 } from '@mochi-labs/core';
 
 import type { BoxCollider } from './collision';
+import {
+  createGameInspectionSnapshot,
+  type GameInspectionSnapshot,
+} from './inspection';
 import { createMaterial } from './materials';
 import type { Disposable, GameScene } from './scene';
 
@@ -9,6 +13,12 @@ type DebugEnabled = boolean | (() => boolean);
 export interface DebugVisual extends Disposable {
   readonly enabled: boolean;
   setEnabled(enabled: boolean): void;
+}
+
+export interface DebugOverlay extends DebugVisual {
+  readonly snapshot: GameInspectionSnapshot;
+  readonly visuals: readonly DebugVisual[];
+  refresh(): GameInspectionSnapshot;
 }
 
 export interface DebugBoxBoundsOptions {
@@ -36,12 +46,111 @@ export interface DebugRayOptions {
   thickness?: number;
 }
 
+export interface DebugOverlayRayOptions extends DebugRayOptions {
+  direction: Vec3 | (() => Vec3);
+  origin: Vec3 | (() => Vec3);
+}
+
+export interface DebugOverlayOptions {
+  boxes?: readonly BoxCollider[];
+  boxOptions?: Omit<DebugBoxBoundsOptions, 'enabled'>;
+  enabled?: DebugEnabled;
+  onSnapshot?: (snapshot: GameInspectionSnapshot) => void;
+  rays?: readonly DebugOverlayRayOptions[];
+  refreshInterval?: number;
+  targets?: readonly Entity[];
+  targetOptions?: Omit<DebugTargetMarkerOptions, 'enabled' | 'id'>;
+}
+
 type EdgeKind = 'north' | 'south' | 'east' | 'west';
 
 interface DebugEdge {
   entity: Entity;
   collider: BoxCollider;
   kind: EdgeKind;
+}
+
+export function createDebugOverlay(
+  scene: GameScene,
+  options: DebugOverlayOptions = {},
+): DebugOverlay {
+  const visuals: DebugVisual[] = [];
+  let enabled = readEnabled(options.enabled, false);
+  let snapshot = createGameInspectionSnapshot(scene.game);
+  let refreshIn = 0;
+  const refreshInterval = Math.max(0, options.refreshInterval ?? 0.25);
+  const isEnabled = () => enabled;
+
+  if (options.boxes?.length) {
+    visuals.push(createDebugBoxBounds(scene, options.boxes, {
+      ...options.boxOptions,
+      enabled: isEnabled,
+    }));
+  }
+
+  for (const target of options.targets ?? []) {
+    visuals.push(createDebugTargetMarker(scene, target, {
+      ...options.targetOptions,
+      enabled: isEnabled,
+    }));
+  }
+
+  for (const ray of options.rays ?? []) {
+    visuals.push(createDebugRay(scene, ray.origin, ray.direction, {
+      ...ray,
+      enabled: isEnabled,
+    }));
+  }
+
+  const refresh = () => {
+    snapshot = createGameInspectionSnapshot(scene.game);
+    options.onSnapshot?.(snapshot);
+    return snapshot;
+  };
+
+  const sync = ({ delta }: FrameContext) => {
+    enabled = readEnabled(options.enabled, enabled);
+    if (!enabled) return;
+
+    refreshIn -= delta;
+    if (refreshIn > 0) return;
+
+    refresh();
+    refreshIn = refreshInterval;
+  };
+
+  refresh();
+  const unsubscribe = scene.onFrame(sync);
+  scene.addReset(() => {
+    refreshIn = 0;
+    refresh();
+  });
+
+  return {
+    get enabled() {
+      return enabled;
+    },
+    get snapshot() {
+      return snapshot;
+    },
+    get visuals() {
+      return visuals;
+    },
+    setEnabled(value) {
+      enabled = value;
+      for (const visual of visuals) {
+        visual.setEnabled(value);
+      }
+      if (value) refresh();
+    },
+    refresh,
+    dispose() {
+      unsubscribe();
+      for (const visual of visuals) {
+        visual.dispose();
+      }
+    },
+  };
 }
 
 export function createDebugBoxBounds(

--- a/packages/gameplay/src/index.ts
+++ b/packages/gameplay/src/index.ts
@@ -17,9 +17,13 @@ export {
 } from './events';
 export {
   createDebugBoxBounds,
+  createDebugOverlay,
   createDebugRay,
   createDebugTargetMarker,
   type DebugBoxBoundsOptions,
+  type DebugOverlay,
+  type DebugOverlayOptions,
+  type DebugOverlayRayOptions,
   type DebugRayOptions,
   type DebugTargetMarkerOptions,
   type DebugVisual,

--- a/packages/gameplay/test/debug.test.ts
+++ b/packages/gameplay/test/debug.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { createDebugRay } from '../src';
+import {
+  createBoxCollider,
+  createDebugOverlay,
+  createDebugRay,
+  setBoxCollisionBody,
+} from '../src';
 import { createHeadlessGame } from './headlessGame';
 
 describe('debug visuals', () => {
@@ -27,5 +32,51 @@ describe('debug visuals', () => {
 
     ray.setEnabled(false);
     assert.equal(entity?.transform.scale.z, 0);
+  });
+
+  it('creates scene-owned debug overlays with inspection snapshots', () => {
+    const game = createHeadlessGame();
+    const scene = game.createScene();
+    const blocker = scene.createEntity({
+      id: 'blocker',
+      tags: ['blocker'],
+      transform: { scale: { x: 2, y: 1, z: 3 } },
+    });
+    const target = scene.createEntity({ id: 'target', tags: ['actor'] });
+    const snapshots: number[] = [];
+
+    setBoxCollisionBody(blocker, { halfX: 1, halfY: 0.5, halfZ: 1.5 });
+    const overlay = createDebugOverlay(scene, {
+      boxes: [createBoxCollider(blocker)],
+      enabled: true,
+      targets: [target],
+      rays: [
+        {
+          id: 'overlay-ray',
+          origin: () => target.transform.position,
+          direction: { x: 1, y: 0, z: 0 },
+          length: 5,
+        },
+      ],
+      onSnapshot: (snapshot) => snapshots.push(snapshot.entityCount),
+    });
+
+    game.runtime.tick(0.25);
+
+    assert.equal(overlay.enabled, true);
+    assert.equal(overlay.visuals.length, 3);
+    assert.ok(overlay.snapshot.entityCount >= 8);
+    assert.deepEqual(
+      overlay.snapshot.tags.map((entry) => entry.tag),
+      ['actor', 'blocker'],
+    );
+    assert.ok(snapshots.length >= 2);
+    assert.equal(game.world.getEntity('overlay-ray')?.transform.scale.z, 5);
+
+    overlay.setEnabled(false);
+    assert.equal(game.world.getEntity('overlay-ray')?.transform.scale.z, 0);
+
+    overlay.dispose();
+    assert.equal(game.world.getEntity('overlay-ray'), undefined);
   });
 });


### PR DESCRIPTION
## Summary
- add `createDebugOverlay` to `@mochi-labs/gameplay` for scene-owned bounds, target markers, rays, and throttled inspection snapshots
- refactor the Tactics Board demo to consume the public overlay helper instead of stitching debug visuals and scheduler refreshes locally
- update roadmap/API docs and add focused gameplay tests for overlay behavior

## Validation
- `pnpm.cmd verify`

## Version impact
- Semver minor: this exports a new backward-compatible public gameplay helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new exported debug helper that runs per-frame and periodically captures inspection snapshots; incorrect enable/refresh behavior could impact performance or leak scene-owned entities if disposal/reset paths are wrong.
> 
> **Overview**
> Adds a new `createDebugOverlay` API to `@mochi-labs/gameplay` that bundles debug box bounds, target markers, rays, and throttled `createGameInspectionSnapshot` refreshes behind a single scene-owned helper (with `refresh()`, `snapshot`, and unified enable/disable + disposal behavior).
> 
> Refactors the `TacticsBoardDemo` debug toggle to use the overlay instead of manually wiring `createDebug*` helpers plus `createSceneScheduler`-based snapshot polling, and updates docs/roadmap plus gameplay tests to cover overlay snapshot callbacks, enable/disable, and disposal cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9943de33499565a9a2af06be5e07dc1622884466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->