### PR TITLE
Refactor playground app shell (demo registry + composable chrome)

### DIFF
--- a/apps/playground/src/App.vue
+++ b/apps/playground/src/App.vue
@@ -1,74 +1,25 @@
 <script setup lang="ts">
 import { GameCanvas } from '@mochi-labs/vue';
-import { computed, shallowRef } from 'vue';
+import { computed } from 'vue';
 
-import FirstPersonRangeDemo from './demos/FirstPersonRangeDemo.vue';
-import NightfallDemo from './DemoScene.vue';
-import OrbitalIslandsDemo from './demos/OrbitalIslandsDemo.vue';
-import PresetLabDemo from './demos/PresetLabDemo.vue';
-import StarfieldDriftDemo from './demos/StarfieldDriftDemo.vue';
-import TacticsBoardDemo from './demos/TacticsBoardDemo.vue';
-import VelocityCircuitDemo from './demos/VelocityCircuitDemo.vue';
+import DemoShellHeader from './components/playground/DemoShellHeader.vue';
+import DemoSwitcherBar from './components/playground/DemoSwitcherBar.vue';
+import { usePlaygroundDemoSelection } from './composables/usePlaygroundDemoSelection';
+import { demoRegistry } from './demoRegistry';
 
-type DemoId =
-  | 'nightfall'
-  | 'orbital'
-  | 'starfield'
-  | 'velocity'
-  | 'presets'
-  | 'range'
-  | 'tactics';
+const { selectedDemo, currentDemo, selectDemo } = usePlaygroundDemoSelection(demoRegistry);
 
-const demos = [
-  { id: 'nightfall', label: 'Nightfall Run', component: NightfallDemo },
-  { id: 'orbital', label: 'Orbital Islands', component: OrbitalIslandsDemo },
-  { id: 'starfield', label: 'Starfield Drift', component: StarfieldDriftDemo },
-  { id: 'velocity', label: 'Velocity Circuit', component: VelocityCircuitDemo },
-  { id: 'presets', label: 'Preset Lab', component: PresetLabDemo },
-  { id: 'range', label: 'First Person Range', component: FirstPersonRangeDemo },
-  { id: 'tactics', label: 'Tactics Board', component: TacticsBoardDemo },
-] as const;
-
-const params = new URLSearchParams(window.location.search);
-const initialDemo = params.get('demo') as DemoId | null;
-
-const selectedDemo = shallowRef<DemoId>(
-  demos.some((demo) => demo.id === initialDemo) ? initialDemo! : 'nightfall',
+const demoTabs = computed(() =>
+  demoRegistry.map((demo) => ({ id: demo.id, label: demo.label })),
 );
-
-const currentDemo = computed(
-  () => demos.find((demo) => demo.id === selectedDemo.value) ?? demos[0],
-);
-
-function selectDemo(id: DemoId) {
-  selectedDemo.value = id;
-
-  const url = new URL(window.location.href);
-  url.searchParams.set('demo', id);
-  window.history.replaceState({}, '', url);
-}
 </script>
 
 <template>
   <div class="app">
     <main class="app__viewport">
       <GameCanvas class="app__canvas">
-        <nav class="app__switcher" aria-label="Demo switcher">
-          <button
-            v-for="demo in demos"
-            :key="demo.id"
-            class="app__switcher-button"
-            :class="{ 'app__switcher-button--active': demo.id === selectedDemo }"
-            type="button"
-            @click="selectDemo(demo.id)"
-          >
-            {{ demo.label }}
-          </button>
-        </nav>
-        <header class="app__header">
-          <h1 class="app__title">Mochi</h1>
-          <p class="app__subtitle">{{ currentDemo.label }}</p>
-        </header>
+        <DemoSwitcherBar :demos="demoTabs" :selected-id="selectedDemo" @select="selectDemo" />
+        <DemoShellHeader brand-title="Mochi" :demo-label="currentDemo.label" />
         <component :is="currentDemo.component" />
       </GameCanvas>
     </main>
@@ -93,62 +44,6 @@ body,
     Segoe UI,
     Roboto,
     sans-serif;
-}
-
-.app__header {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  z-index: 1;
-  text-align: right;
-  pointer-events: none;
-}
-
-.app__switcher {
-  position: absolute;
-  left: 50%;
-  bottom: 1rem;
-  z-index: 2;
-  display: flex;
-  max-width: calc(100% - 2rem);
-  padding: 0.35rem;
-  gap: 0.5rem;
-  overflow-x: auto;
-  border: 1px solid rgb(255 255 255 / 14%);
-  border-radius: 999px;
-  background: rgb(5 5 8 / 72%);
-  backdrop-filter: blur(12px);
-  transform: translateX(-50%);
-}
-
-.app__switcher-button {
-  flex: 0 0 auto;
-  padding: 0.45rem 0.7rem;
-  border: 0;
-  border-radius: 999px;
-  background: transparent;
-  color: #e8e8ec;
-  font: inherit;
-  font-size: 0.78rem;
-  cursor: pointer;
-}
-
-.app__switcher-button--active {
-  background: #e8e8ec;
-  color: #090b12;
-}
-
-.app__title {
-  margin: 0;
-  font-size: 1.1rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.app__subtitle {
-  margin: 0.2rem 0 0;
-  font-size: 0.8rem;
-  opacity: 0.75;
 }
 
 .app__viewport {

--- a/apps/playground/src/components/playground/DemoShellHeader.vue
+++ b/apps/playground/src/components/playground/DemoShellHeader.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+defineProps<{
+  brandTitle: string;
+  demoLabel: string;
+}>();
+</script>
+
+<template>
+  <header class="demo-shell-header">
+    <h1 class="demo-shell-header__title">{{ brandTitle }}</h1>
+    <p class="demo-shell-header__subtitle">{{ demoLabel }}</p>
+  </header>
+</template>
+
+<style scoped>
+.demo-shell-header {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1;
+  text-align: right;
+  pointer-events: none;
+}
+
+.demo-shell-header__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.demo-shell-header__subtitle {
+  margin: 0.2rem 0 0;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+</style>

--- a/apps/playground/src/components/playground/DemoSwitcherBar.vue
+++ b/apps/playground/src/components/playground/DemoSwitcherBar.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import type { DemoId } from '../../demoRegistry';
+
+defineProps<{
+  demos: readonly { id: DemoId; label: string }[];
+  selectedId: DemoId;
+}>();
+
+const emit = defineEmits<{
+  select: [id: DemoId];
+}>();
+</script>
+
+<template>
+  <nav class="demo-switcher" aria-label="Demo switcher">
+    <button
+      v-for="demo in demos"
+      :key="demo.id"
+      class="demo-switcher__button"
+      :class="{ 'demo-switcher__button--active': demo.id === selectedId }"
+      type="button"
+      @click="emit('select', demo.id)"
+    >
+      {{ demo.label }}
+    </button>
+  </nav>
+</template>
+
+<style scoped>
+.demo-switcher {
+  position: absolute;
+  left: 50%;
+  bottom: 1rem;
+  z-index: 2;
+  display: flex;
+  max-width: calc(100% - 2rem);
+  padding: 0.35rem;
+  gap: 0.5rem;
+  overflow-x: auto;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: 999px;
+  background: rgb(5 5 8 / 72%);
+  backdrop-filter: blur(12px);
+  transform: translateX(-50%);
+}
+
+.demo-switcher__button {
+  flex: 0 0 auto;
+  padding: 0.45rem 0.7rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: #e8e8ec;
+  font: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.demo-switcher__button--active {
+  background: #e8e8ec;
+  color: #090b12;
+}
+</style>

--- a/apps/playground/src/composables/usePlaygroundDemoSelection.ts
+++ b/apps/playground/src/composables/usePlaygroundDemoSelection.ts
@@ -1,0 +1,26 @@
+import { computed, shallowRef } from 'vue';
+
+import type { DemoDefinition, DemoId } from '../demoRegistry';
+
+export function usePlaygroundDemoSelection(demos: readonly DemoDefinition[]) {
+  const params = new URLSearchParams(window.location.search);
+  const initial = params.get('demo') as DemoId | null;
+
+  const selectedDemo = shallowRef<DemoId>(
+    initial && demos.some((demo) => demo.id === initial) ? initial : demos[0].id,
+  );
+
+  const currentDemo = computed(
+    () => demos.find((demo) => demo.id === selectedDemo.value) ?? demos[0],
+  );
+
+  function selectDemo(id: DemoId) {
+    selectedDemo.value = id;
+
+    const url = new URL(window.location.href);
+    url.searchParams.set('demo', id);
+    window.history.replaceState({}, '', url);
+  }
+
+  return { selectedDemo, currentDemo, selectDemo };
+}

--- a/apps/playground/src/demoRegistry.ts
+++ b/apps/playground/src/demoRegistry.ts
@@ -1,0 +1,34 @@
+import type { Component } from 'vue';
+
+import FirstPersonRangeDemo from './demos/FirstPersonRangeDemo.vue';
+import NightfallDemo from './DemoScene.vue';
+import OrbitalIslandsDemo from './demos/OrbitalIslandsDemo.vue';
+import PresetLabDemo from './demos/PresetLabDemo.vue';
+import StarfieldDriftDemo from './demos/StarfieldDriftDemo.vue';
+import TacticsBoardDemo from './demos/TacticsBoardDemo.vue';
+import VelocityCircuitDemo from './demos/VelocityCircuitDemo.vue';
+
+export type DemoId =
+  | 'nightfall'
+  | 'orbital'
+  | 'starfield'
+  | 'velocity'
+  | 'presets'
+  | 'range'
+  | 'tactics';
+
+export interface DemoDefinition {
+  readonly id: DemoId;
+  readonly label: string;
+  readonly component: Component;
+}
+
+export const demoRegistry: readonly DemoDefinition[] = [
+  { id: 'nightfall', label: 'Nightfall Run', component: NightfallDemo },
+  { id: 'orbital', label: 'Orbital Islands', component: OrbitalIslandsDemo },
+  { id: 'starfield', label: 'Starfield Drift', component: StarfieldDriftDemo },
+  { id: 'velocity', label: 'Velocity Circuit', component: VelocityCircuitDemo },
+  { id: 'presets', label: 'Preset Lab', component: PresetLabDemo },
+  { id: 'range', label: 'First Person Range', component: FirstPersonRangeDemo },
+  { id: 'tactics', label: 'Tactics Board', component: TacticsBoardDemo },
+];


### PR DESCRIPTION
## Summary

Applies Vue best-practice layering to the playground entry: thin \App.vue\, explicit props/emit children, and URL-synced demo selection in a composable.

## Changes

- \demoRegistry.ts\: single demo list (\DemoId\, labels, components) for dynamic \<component :is />\.
- \usePlaygroundDemoSelection\: \?demo=\ hydration, shallow ref for selection, computed current demo.
- \DemoSwitcherBar\ / \DemoShellHeader\: scoped presentational shells.
- Root layout CSS stays on \App.vue\; nav/header styles colocated.

## Verification

\pnpm --filter playground build\ (vue-tsc + vite) succeeds locally.